### PR TITLE
Selecting a Goal should Launch the Behavior Picker

### DIFF
--- a/src/main/java/org/tndata/android/compass/activity/ChooseGoalsActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/ChooseGoalsActivity.java
@@ -4,6 +4,7 @@ package org.tndata.android.compass.activity;
 import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
@@ -39,7 +40,10 @@ import org.tndata.android.compass.util.ImageHelper;
 import java.util.ArrayList;
 import java.util.HashSet;
 
-
+/**
+ * The ChooseGoalsActivity is where a user selects Goals within a selected Category.
+ *
+ */
 public class ChooseGoalsActivity extends ActionBarActivity implements AddGoalTask
         .AddGoalsTaskListener,
         GoalLoaderTask.GoalLoaderListener, DeleteGoalTask.DeleteGoalTaskListener {
@@ -300,6 +304,8 @@ public class ChooseGoalsActivity extends ActionBarActivity implements AddGoalTas
     }
 
     public void goalSelected(Goal goal) {
+        // When a goal has been selected, save it in our list of selected goals, and then
+        // immediately launch the user into the Behavior Selection workflow.
 
         if (mSelectedGoals.contains(goal)) {
             mSelectedGoals.remove(goal);
@@ -307,6 +313,12 @@ public class ChooseGoalsActivity extends ActionBarActivity implements AddGoalTas
             mSelectedGoals.add(goal);
         }
         mAdapter.notifyDataSetChanged();
+
+        // Launch the GoalTryActivity (where users choose a behavior for the Goal)
+        Intent intent = new Intent(getApplicationContext(), GoalTryActivity.class);
+        intent.putExtra("goal", goal);
+        intent.putExtra("category", mCategory);
+        startActivity(intent);
     }
 
     public void moreInfoPressed(Goal goal) {

--- a/src/main/java/org/tndata/android/compass/activity/GoalTryActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/GoalTryActivity.java
@@ -16,7 +16,6 @@ import android.view.KeyEvent;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -37,8 +36,13 @@ import org.tndata.android.compass.util.ImageCache;
 import java.util.ArrayList;
 import java.util.HashSet;
 
+/**
+ * The GoalTryActivity is where a user selects Behaviors for a chosen Goal.
+ * 
+ */
 public class GoalTryActivity extends ActionBarActivity implements
         BehaviorLoaderListener {
+
     private Toolbar mToolbar;
     private Goal mGoal;
     private ArrayList<Behavior> mBehaviorList;
@@ -59,12 +63,12 @@ public class GoalTryActivity extends ActionBarActivity implements
                     .findViewById(R.id.list_item_behavior_title_textview);
             descriptionTextView = (TextView) itemView
                     .findViewById(R.id.list_item_behavior_description_textview);
-            tryIt = (Button) itemView.findViewById(R.id.list_item_behavior_try_it_button);
+            tryItTextView = (TextView) itemView.findViewById(R.id.list_item_behavior_try_it_textview);
         }
 
         TextView titleTextView;
         TextView descriptionTextView;
-        Button tryIt;
+        TextView tryItTextView;
         ImageView iconImageView;
     }
 
@@ -106,12 +110,12 @@ public class GoalTryActivity extends ActionBarActivity implements
                 if (mExpandedBehaviors.contains(behavior)) {
                     ((TryGoalViewHolder) viewHolder).descriptionTextView.setVisibility(View
                             .VISIBLE);
-                    ((TryGoalViewHolder) viewHolder).tryIt.setVisibility(View.VISIBLE);
+                    ((TryGoalViewHolder) viewHolder).tryItTextView.setVisibility(View.VISIBLE);
                     ((TryGoalViewHolder) viewHolder).iconImageView.setVisibility(View.GONE);
                 } else {
                     ((TryGoalViewHolder) viewHolder).descriptionTextView.setVisibility(View
                             .GONE);
-                    ((TryGoalViewHolder) viewHolder).tryIt.setVisibility(View.GONE);
+                    ((TryGoalViewHolder) viewHolder).tryItTextView.setVisibility(View.GONE);
                     ((TryGoalViewHolder) viewHolder).iconImageView.setVisibility(View.VISIBLE);
                 }
                 if (behavior.getIconUrl() != null
@@ -121,7 +125,7 @@ public class GoalTryActivity extends ActionBarActivity implements
                             behavior.getIconUrl(), false);
                 }
 
-                ((TryGoalViewHolder) viewHolder).tryIt.setOnClickListener(new View
+                ((TryGoalViewHolder) viewHolder).tryItTextView.setOnClickListener(new View
                         .OnClickListener() {
 
                     @Override

--- a/src/main/res/layout/list_item_behavior.xml
+++ b/src/main/res/layout/list_item_behavior.xml
@@ -49,23 +49,22 @@
             android:visibility="gone"/>
 
 
-        <Button
-            android:id="@+id/list_item_behavior_try_it_button"
+        <TextView
+            android:id="@+id/list_item_behavior_try_it_textview"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_gravity="right"
+            android:gravity="center"
+            android:layout_margin="10dp"
+            android:layout_alignParentEnd="true"
             android:layout_alignParentRight="true"
-            android:layout_below="@id/list_item_behavior_description_textview"
-            android:layout_marginBottom="10dp"
-            android:layout_marginLeft="15dp"
-            android:layout_marginRight="10dp"
-            android:layout_marginTop="10dp"
-            android:background="@drawable/button_paper_flat"
+            android:paddingLeft="10dp"
+            android:paddingRight="10dp"
             android:minHeight="@dimen/paper_flat_button_min_height"
-            android:paddingLeft="5dp"
-            android:paddingRight="5dp"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textColor="@color/grow_primary"
+            android:layout_below="@id/list_item_behavior_description_textview"
             android:text="@string/goal_behavior_try_it"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:textColor="@drawable/button_paper_flat_text_selector"
             android:visibility="gone"/>
     </RelativeLayout>
 


### PR DESCRIPTION
From [this card](https://trello.com/c/1hSLMlcv/144-user-scenario-for-selecting-goals-behaviors-actions):

> As soon as I select a Goal, it should launch that goal's behavior library. Then after selecting behaviors & actions (or hitting the back button), I get back to the list of goals; at which point I can choose a new goal and repeat.

This PR also converts the button in the Behavior Cards to material design specs (https://trello.com/c/kSRx9kty/123-change-cta-button-on-behavior-cards-to-material-specs)