### PR TITLE
More State Management updates & Fix for Goal Card CTAs

### DIFF
--- a/src/main/java/org/tndata/android/compass/CompassApplication.java
+++ b/src/main/java/org/tndata/android/compass/CompassApplication.java
@@ -58,7 +58,12 @@ public class CompassApplication extends Application {
     public void removeCategory(Category category) {
         mCategories.remove(category);
     }
-    
+
+    /* Returns all of the goals for a given Category */
+    public ArrayList<Goal> getCategoryGoals(Category category) {
+        return category.getGoals();
+    }
+
     public ArrayList<Goal> getGoals() {
         return mGoals;
     }

--- a/src/main/java/org/tndata/android/compass/CompassApplication.java
+++ b/src/main/java/org/tndata/android/compass/CompassApplication.java
@@ -57,6 +57,11 @@ public class CompassApplication extends Application {
     /* Remove a single Category from the user's collection */
     public void removeCategory(Category category) {
         mCategories.remove(category);
+
+        // also remove this category from any child goals
+        for(Goal goal : mGoals) {
+            goal.removeCategory(category);
+        }
     }
 
     /* Returns all of the goals for a given Category */
@@ -87,6 +92,11 @@ public class CompassApplication extends Application {
     /* Remove a single Goal from the user's collection */
     public void removeGoal(Goal goal) {
         mGoals.remove(goal);
+
+        // Remove the goal from its parent categories
+        for(Category category : mCategories) {
+            category.removeGoal(goal);
+        }
     }
 
     /**
@@ -125,6 +135,11 @@ public class CompassApplication extends Application {
     /* Remove a single Behavior from a user's collection */
     public void removeBehavior(Behavior behavior) {
         mBehaviors.remove(behavior);
+
+        // Remove the behavior from any Goals
+        for(Goal goal : getGoals()) {
+            goal.removeBehavior(behavior);
+        }
     }
 
     public void addBehavior(Behavior behavior) {
@@ -157,6 +172,11 @@ public class CompassApplication extends Application {
     /* Remove a single Action from a user's collection */
     public void removeAction(Action action) {
         mActions.remove(action);
+
+        // Remove the action from any related behaviors
+        for(Behavior behavior : mBehaviors) {
+            behavior.removeAction(action);
+        }
     }
 
     public void setActions(ArrayList<Action> actions) {

--- a/src/main/java/org/tndata/android/compass/CompassApplication.java
+++ b/src/main/java/org/tndata/android/compass/CompassApplication.java
@@ -51,7 +51,7 @@ public class CompassApplication extends Application {
             Log.d(TAG, "--> setCategory: " + c.getTitle());
         }
 
-        logSelectedData("AFTER setCategories");
+        logSelectedData("AFTER CompassApplication.setCategories");
     }
 
     /* Remove a single Category from the user's collection */
@@ -62,6 +62,7 @@ public class CompassApplication extends Application {
         for(Goal goal : mGoals) {
             goal.removeCategory(category);
         }
+        logSelectedData("AFTER CompassApplication.removeCategory");
     }
 
     /* Returns all of the goals for a given Category */
@@ -79,7 +80,7 @@ public class CompassApplication extends Application {
             Log.d(TAG, "--> setGoals: " + g.getTitle());
         }
         assignGoalsToCategories();
-        logSelectedData("AFTER setGoals");
+        logSelectedData("AFTER CompassApplication.setGoals");
     }
 
     public void addGoal(Goal goal) {
@@ -87,6 +88,7 @@ public class CompassApplication extends Application {
             mGoals.add(goal);
             assignGoalsToCategories();
         }
+        logSelectedData("AFTER CompassApplication.addGoal: " + goal.getTitle());
     }
 
     /* Remove a single Goal from the user's collection */
@@ -97,6 +99,8 @@ public class CompassApplication extends Application {
         for(Category category : mCategories) {
             category.removeGoal(goal);
         }
+
+        logSelectedData("AFTER CompassApplication.removeGoal: " + goal.getTitle());
     }
 
     /**
@@ -125,7 +129,7 @@ public class CompassApplication extends Application {
             Log.d(TAG, "--> setBehavior: " + b.getTitle());
         }
         assignBehaviorsToGoals();
-        logSelectedData("AFTER setBehaviors");
+        logSelectedData("AFTER CompassApplication.setBehaviors");
     }
 
     public ArrayList<Behavior> getBehaviors() {
@@ -140,21 +144,25 @@ public class CompassApplication extends Application {
         for(Goal goal : getGoals()) {
             goal.removeBehavior(behavior);
         }
+        logSelectedData("AFTER CompassApplication.removeBehavior: " + behavior.getTitle());
     }
 
     public void addBehavior(Behavior behavior) {
-        mBehaviors.add(behavior);
-        assignBehaviorsToGoals();
+        if(!mBehaviors.contains(behavior)) {
+            mBehaviors.add(behavior);
+            assignBehaviorsToGoals();
+            logSelectedData("AFTER CompassApplication.addBehavior: " + behavior.getTitle());
+        }
     }
 
     /** Behaviors are contained within a Goal. This method will take the list
      * of selected behaviors, and associate them with the user's selected goals.
      */
     public void assignBehaviorsToGoals() {
-        for (Goal goal : getGoals()) {
+        for (Goal goal : getGoals()) { // Look at all the selected goals
             ArrayList<Behavior> goalBehaviors = new ArrayList<Behavior>();
-            for (Behavior behavior : getBehaviors()) {
-                for (Goal behaviorGoal : behavior.getGoals()) {
+            for (Behavior behavior : getBehaviors()) { // look at all the selected behaviors...
+                for (Goal behaviorGoal : behavior.getGoals()) { // The Behavior's Parent goals
                     if (behaviorGoal.getId() == goal.getId()) {
                         goalBehaviors.add(behavior);
                         break;
@@ -177,6 +185,8 @@ public class CompassApplication extends Application {
         for(Behavior behavior : mBehaviors) {
             behavior.removeAction(action);
         }
+
+        logSelectedData("AFTER CompassApplication.removeAction: " + action.getTitle());
     }
 
     public void setActions(ArrayList<Action> actions) {
@@ -185,7 +195,7 @@ public class CompassApplication extends Application {
             Log.d(TAG, "--> setAction: " + a.getTitle());
         }
         assignActionsToBehaviors();
-        logSelectedData("AFTER setActions");
+        logSelectedData("AFTER CompassApplication.setActions");
     }
 
     /* Add an individual action the user's collection */
@@ -193,7 +203,7 @@ public class CompassApplication extends Application {
         if(!mActions.contains(action)) {
             mActions.add(action);
             assignActionsToBehaviors();
-            logSelectedData("AFTER addAction");
+            logSelectedData("AFTER CompassApplication.addAction: " + action.getTitle());
         }
     }
 
@@ -228,7 +238,6 @@ public class CompassApplication extends Application {
                     behaviorActions.add(action);
                     break;
                 }
-
             }
             behavior.setActions(behaviorActions);
         }

--- a/src/main/java/org/tndata/android/compass/activity/GoalTryActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/GoalTryActivity.java
@@ -379,12 +379,10 @@ public class GoalTryActivity extends ActionBarActivity implements
     public void behaviorsAdded(ArrayList<Behavior> behaviors) {
         if(behaviors != null) {
             for(Behavior b : behaviors) {
-                Log.d("GoalTryActivity", "Added Behavior(s): " + b.getId() + ", " + b.getTitle());
-                Log.d("GoalTryActivity", "-- mapping id: " + b.getMappingId());
                 application.addBehavior(b);
             }
         } else {
-            Log.d("GoalTryActivity", "No behaviors added");
+            Log.e("GoalTryActivity", "No behaviors added");
         }
         mAdapter.notifyDataSetChanged();
         Toast.makeText(this, getText(R.string.goal_try_behavior_added), Toast.LENGTH_SHORT).show();

--- a/src/main/java/org/tndata/android/compass/adapter/CategoryFragmentAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/CategoryFragmentAdapter.java
@@ -15,12 +15,11 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import org.tndata.android.compass.CompassApplication;
 import org.tndata.android.compass.R;
 import org.tndata.android.compass.model.Category;
 import org.tndata.android.compass.model.Goal;
 import org.tndata.android.compass.ui.CompassPopupMenu;
-
-import java.util.List;
 
 public class CategoryFragmentAdapter extends
         RecyclerView.Adapter<RecyclerView.ViewHolder> {
@@ -85,37 +84,34 @@ public class CategoryFragmentAdapter extends
 
     }
 
+    private CompassApplication mApplication;
     private Context mContext;
     private Category mCategory;
-    private List<Goal> mItems;
     private CategoryFragmentAdapterInterface mCallback;
+    private final String TAG = "CatFragAdapter";
 
-    public CategoryFragmentAdapter(Context context, List<Goal> objects, Category category,
-                                   CategoryFragmentAdapterInterface callback) {
-        if (objects == null) {
+    public CategoryFragmentAdapter(Context context, CompassApplication application, Category category,
+            CategoryFragmentAdapterInterface callback) {
+
+        if (application.getCategoryGoals(category) == null) {
             throw new IllegalArgumentException("Goals List must not be null");
         }
-        this.mItems = objects;
+
+        this.mApplication = application;
         this.mContext = context;
         this.mCategory = category;
         this.mCallback = callback;
     }
 
-    public void updateEntries(List<Goal> items) {
-        mItems.clear();
-        mItems.addAll(items);
-        notifyDataSetChanged();
-    }
-
     @Override
     public int getItemCount() {
-        return mItems.size();
+        return mApplication.getCategoryGoals(mCategory).size();
     }
 
     @Override
     public void onBindViewHolder(final RecyclerView.ViewHolder viewHolder,
                                  final int position) {
-        final Goal goal = mItems.get(position);
+        final Goal goal = mApplication.getCategoryGoals(mCategory).get(position);
         ((CategoryGoalViewHolder) viewHolder).titleTextView.setText(goal.getTitle());
         ((CategoryGoalViewHolder) viewHolder).descriptionTextView.setText(
                 goal.getDescription());

--- a/src/main/java/org/tndata/android/compass/model/Behavior.java
+++ b/src/main/java/org/tndata/android/compass/model/Behavior.java
@@ -102,6 +102,12 @@ public class Behavior extends TDCBase implements Serializable,
         this.goals = goals;
     }
 
+    public void addGoal(Goal goal) {
+        if(!this.goals.contains(goal)) {
+            this.goals.add(goal);
+        }
+    }
+
     public void removeGoal(Goal goal) {
         if(this.goals.contains(goal)) {
             this.goals.remove(goal);
@@ -114,6 +120,12 @@ public class Behavior extends TDCBase implements Serializable,
 
     public void setActions(ArrayList<Action> actions) {
         this.actions = actions;
+    }
+
+    public void addAction(Action action) {
+        if(!this.actions.contains(action)) {
+            this.actions.add(action);
+        }
     }
 
     public void removeAction(Action action) {

--- a/src/main/java/org/tndata/android/compass/model/Behavior.java
+++ b/src/main/java/org/tndata/android/compass/model/Behavior.java
@@ -102,12 +102,24 @@ public class Behavior extends TDCBase implements Serializable,
         this.goals = goals;
     }
 
+    public void removeGoal(Goal goal) {
+        if(this.goals.contains(goal)) {
+            this.goals.remove(goal);
+        }
+    }
+
     public ArrayList<Action> getActions() {
         return actions;
     }
 
     public void setActions(ArrayList<Action> actions) {
         this.actions = actions;
+    }
+
+    public void removeAction(Action action) {
+        if(this.actions.contains(action)) {
+            this.actions.remove(action);
+        }
     }
 
     @Override

--- a/src/main/java/org/tndata/android/compass/model/Category.java
+++ b/src/main/java/org/tndata/android/compass/model/Category.java
@@ -85,7 +85,9 @@ public class Category extends TDCBase implements Serializable,
     }
 
     public void removeGoal(Goal goal) {
-        this.goals.remove(goal);
+        if(this.goals.contains(goal)) {
+            this.goals.remove(goal);
+        }
     }
 
     public String getColor() {

--- a/src/main/java/org/tndata/android/compass/model/Category.java
+++ b/src/main/java/org/tndata/android/compass/model/Category.java
@@ -84,6 +84,12 @@ public class Category extends TDCBase implements Serializable,
         this.goals = goals;
     }
 
+    public void addGoal(Goal goal) {
+        if(!this.goals.contains(goal)) {
+            this.goals.add(goal);
+        }
+    }
+
     public void removeGoal(Goal goal) {
         if(this.goals.contains(goal)) {
             this.goals.remove(goal);

--- a/src/main/java/org/tndata/android/compass/model/Goal.java
+++ b/src/main/java/org/tndata/android/compass/model/Goal.java
@@ -79,12 +79,24 @@ public class Goal extends TDCBase implements Serializable, Comparable<Goal> {
         this.categories = categories;
     }
 
+    public void addCategory(Category category) {
+        if(!this.categories.contains(category)) {
+            this.categories.add(category);
+        }
+    }
+
     public ArrayList<Behavior> getBehaviors() {
         return behaviors;
     }
 
     public void setBehaviors(ArrayList<Behavior> behaviors) {
         this.behaviors = behaviors;
+    }
+
+    public void addBehavior(Behavior behavior) {
+        if(!this.behaviors.contains(behavior)) {
+            this.behaviors.add(behavior);
+        }
     }
 
     public void removeBehavior(Behavior behavior) {

--- a/src/main/java/org/tndata/android/compass/model/Goal.java
+++ b/src/main/java/org/tndata/android/compass/model/Goal.java
@@ -69,6 +69,12 @@ public class Goal extends TDCBase implements Serializable, Comparable<Goal> {
         return categories;
     }
 
+    public void removeCategory(Category category) {
+        if(this.categories.contains(category)) {
+            this.categories.remove(category);
+        }
+    }
+
     public void setCategories(ArrayList<Category> categories) {
         this.categories = categories;
     }
@@ -79,6 +85,12 @@ public class Goal extends TDCBase implements Serializable, Comparable<Goal> {
 
     public void setBehaviors(ArrayList<Behavior> behaviors) {
         this.behaviors = behaviors;
+    }
+
+    public void removeBehavior(Behavior behavior) {
+        if(this.behaviors.contains(behavior)) {
+            this.behaviors.remove(behavior);
+        }
     }
 
     public void setProgressValue(double value) {

--- a/src/main/java/org/tndata/android/compass/task/AddBehaviorTask.java
+++ b/src/main/java/org/tndata/android/compass/task/AddBehaviorTask.java
@@ -1,21 +1,5 @@
 package org.tndata.android.compass.task;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.tndata.android.compass.CompassApplication;
-import org.tndata.android.compass.model.Behavior;
-import org.tndata.android.compass.util.Constants;
-import org.tndata.android.compass.util.NetworkHelper;
-
 import android.app.Activity;
 import android.content.Context;
 import android.os.AsyncTask;
@@ -25,6 +9,23 @@ import android.util.Log;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.tndata.android.compass.CompassApplication;
+import org.tndata.android.compass.model.Behavior;
+import org.tndata.android.compass.model.Goal;
+import org.tndata.android.compass.util.Constants;
+import org.tndata.android.compass.util.NetworkHelper;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 public class AddBehaviorTask extends AsyncTask<Void, Void, ArrayList<Behavior>> {
     private Context mContext;
@@ -93,6 +94,15 @@ public class AddBehaviorTask extends AsyncTask<Void, Void, ArrayList<Behavior>> 
                 Behavior behavior = gson.fromJson(userBehavior.getString("behavior"),
                         Behavior.class);
                 behavior.setMappingId(userBehavior.getInt("id"));
+
+                // Include the Behavior's Parent goals that have been selected by the user
+                JSONArray goalArray = userBehavior.getJSONArray("user_goals");
+                ArrayList<Goal> goals = behavior.getGoals();
+                for (int x = 0; x < goalArray.length(); x++) {
+                    Goal goal = gson.fromJson(goalArray.getString(x), Goal.class);
+                    goals.add(goal);
+                }
+                behavior.setGoals(goals);
                 behaviors.add(behavior);
             }
 

--- a/src/main/java/org/tndata/android/compass/ui/parallaxrecyclerview/HeaderLayoutManagerFixed.java
+++ b/src/main/java/org/tndata/android/compass/ui/parallaxrecyclerview/HeaderLayoutManagerFixed.java
@@ -25,7 +25,7 @@ public class HeaderLayoutManagerFixed extends RecyclerView.LayoutManager {
 
     private static final String TAG = "LinearLayoutManager";
 
-    private static final boolean DEBUG = true;
+    private static final boolean DEBUG = false;
 
     public static final int HORIZONTAL = LinearLayout.HORIZONTAL;
 


### PR DESCRIPTION
This PR includes several additional fixes to the application state management:

* When a user selects a Behavior, we now connect it to its parent goals.
* When a user selects an Action, we now connect it to its parent Behavior
* The `CompassApplication` should now be able to keep up with the nested state of user-selected data
* the models have several additional methods for managing state

Additionally, this PR fixes the bug where a Goal Card's CTA link would not update after selecting a Behavior.