### PR TITLE
don't crash if there are no selected any behaviors

### DIFF
--- a/src/main/java/org/tndata/android/compass/activity/BehaviorProgressActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/BehaviorProgressActivity.java
@@ -47,8 +47,10 @@ public class BehaviorProgressActivity extends Activity implements
 
     @Override
     public void behaviorsLoaded(ArrayList<Behavior> behaviors) {
-        mBehaviorList.addAll(behaviors);
-        mProgressBar.setVisibility(View.GONE);
+        if(behaviors != null && !behaviors.isEmpty()) {
+            mBehaviorList.addAll(behaviors);
+            mProgressBar.setVisibility(View.GONE);
+        }
         setCurrentBehavior();
     }
 


### PR DESCRIPTION
... this is the issue that caused the app to crash when tapping on the Behavior notification.