### PR TITLE
Refactor how we store user-selected data

### DIFF
--- a/src/main/java/org/tndata/android/compass/CompassApplication.java
+++ b/src/main/java/org/tndata/android/compass/CompassApplication.java
@@ -77,15 +77,17 @@ public class CompassApplication extends Application {
 
     public void addGoal(Goal goal) {
         mUserData.addGoal(goal);
+        mUserData.logSelectedData("AFTER CompassApplication.addGoal", false);
     }
 
     public void removeGoal(Goal goal) {
         mUserData.removeGoal(goal);
+        mUserData.logSelectedData("AFTER CompassApplication.removeGoal", false);
     }
 
     public void setBehaviors(ArrayList<Behavior> behaviors) {
         mUserData.setBehaviors(behaviors);
-        mUserData.logSelectedData("AFTER CompassApplication.setBehaviors");
+        mUserData.logSelectedData("AFTER CompassApplication.setBehaviors", false);
     }
 
     public ArrayList<Behavior> getBehaviors() {
@@ -94,11 +96,12 @@ public class CompassApplication extends Application {
 
     public void removeBehavior(Behavior behavior) {
         mUserData.removeBehavior(behavior);
-        mUserData.logSelectedData("AFTER CompassApplication.removeBehavior: " + behavior.getTitle());
+        mUserData.logSelectedData("AFTER CompassApplication.removeBehavior: ", false);
     }
 
     public void addBehavior(Behavior behavior) {
         mUserData.addBehavior(behavior);
+        mUserData.logSelectedData("AFTER CompassApplication.addBehavior", false);
     }
 
     public ArrayList<Action> getActions() {
@@ -107,20 +110,22 @@ public class CompassApplication extends Application {
 
     public void removeAction(Action action) {
         mUserData.removeAction(action);
-        mUserData.logSelectedData("AFTER CompassApplication.removeAction: " + action.getTitle());
+        mUserData.logSelectedData("AFTER CompassApplication.removeAction: ", false);
     }
 
     public void setActions(ArrayList<Action> actions) {
         mUserData.setActions(actions);
-        mUserData.logSelectedData("AFTER CompassApplication.setActions");
+        mUserData.logSelectedData("AFTER CompassApplication.setActions", false);
     }
 
     public void addAction(Action action) {
         mUserData.addAction(action);
+        mUserData.logSelectedData("AFTER CompassApplication.addAction", false);
     }
 
     public void updateAction(Action action) {
         mUserData.updateAction(action);
+        mUserData.logSelectedData("AFTER CompassApplication.updateAction", false);
     }
 
     @Override

--- a/src/main/java/org/tndata/android/compass/CompassApplication.java
+++ b/src/main/java/org/tndata/android/compass/CompassApplication.java
@@ -242,6 +242,24 @@ public class CompassApplication extends Application {
             }
             behavior.setActions(behaviorActions);
         }
+
+        // now, set each Action's parent Behavior.
+        setActionParents();
+    }
+
+    /**
+    * This method will set the Behavior attribute for all of the user's selected Actions, so the
+    * Action will contain a reference to its parent.
+    */
+    public void setActionParents() {
+        // set a reference to the parent for each action.
+        for(Action action : getActions()) {
+            for(Behavior behavior : getBehaviors()) {
+                if(action.getBehavior_id() == behavior.getId()) {
+                    action.setBehavior(behavior);
+                }
+            }
+        }
     }
 
     public void logSelectedGoalData(String title) {

--- a/src/main/java/org/tndata/android/compass/CompassApplication.java
+++ b/src/main/java/org/tndata/android/compass/CompassApplication.java
@@ -1,13 +1,13 @@
 package org.tndata.android.compass;
 
 import android.app.Application;
-import android.util.Log;
 
 import org.tndata.android.compass.model.Action;
 import org.tndata.android.compass.model.Behavior;
 import org.tndata.android.compass.model.Category;
 import org.tndata.android.compass.model.Goal;
 import org.tndata.android.compass.model.User;
+import org.tndata.android.compass.model.UserData;
 import org.tndata.android.compass.util.ImageLoader;
 
 import java.util.ArrayList;
@@ -16,10 +16,7 @@ public class CompassApplication extends Application {
     private String TAG = "CompassApplication";
     private String mToken;
     private User mUser; // The logged-in user
-    private ArrayList<Category> mCategories = new ArrayList<Category>(); // The user's selected Categories
-    private ArrayList<Goal> mGoals = new ArrayList<Goal>();  // The user's selected Goals
-    private ArrayList<Behavior> mBehaviors = new ArrayList<Behavior>(); // The user's selected behaviors
-    private ArrayList<Action> mActions = new ArrayList<Action>(); // The user's selected actions
+    private UserData mUserData = new UserData(); // The user's selected content.
 
     public CompassApplication() {
         super();
@@ -41,257 +38,89 @@ public class CompassApplication extends Application {
         mUser = user;
     }
 
+    public UserData getUserData() {
+        return mUserData;
+    }
+
+    public void setUserData(UserData userData) {
+        mUserData = userData;
+    }
+
+    // -------------------------------------------------------------------
+    // The following methods are wrappers around UserData methods; All
+    // of this info used to be stored directly in the CompassApplication
+    // class, so I've left these here for backwards compatibility.
+    // -------------------------------------------------------------------
     public ArrayList<Category> getCategories() {
-        return mCategories;
+        return mUserData.getCategories();
     }
 
     public void setCategories(ArrayList<Category> categories) {
-        mCategories = categories;
-
-        for(Category c: categories) {
-            Log.d(TAG, "--> setCategory: " + c.getTitle());
-        }
-
-        logSelectedData("AFTER CompassApplication.setCategories");
+        mUserData.setCategories(categories);
     }
 
-    /* Remove a single Category from the user's collection */
-    public void removeCategory(Category category) {
-        mCategories.remove(category);
-
-        // also remove this category from any child goals
-        for(Goal goal : mGoals) {
-            goal.removeCategory(category);
-        }
-        logSelectedData("AFTER CompassApplication.removeCategory");
+    public void addCategory(Category category) {
+        mUserData.addCategory(category);
     }
 
-    /* Returns all of the goals for a given Category */
     public ArrayList<Goal> getCategoryGoals(Category category) {
-        return category.getGoals();
+        return mUserData.getCategoryGoals(category);
     }
 
     public ArrayList<Goal> getGoals() {
-        return mGoals;
+        return mUserData.getGoals();
     }
 
     public void setGoals(ArrayList<Goal> goals) {
-        mGoals = goals;
-        for(Goal g: goals) {
-            Log.d(TAG, "--> setGoals: " + g.getTitle());
-        }
-        assignGoalsToCategories();
-        logSelectedData("AFTER CompassApplication.setGoals");
+        mUserData.setGoals(goals);
     }
 
     public void addGoal(Goal goal) {
-        if(!mGoals.contains(goal)) {
-            mGoals.add(goal);
-            assignGoalsToCategories();
-        }
-        logSelectedData("AFTER CompassApplication.addGoal: " + goal.getTitle());
+        mUserData.addGoal(goal);
     }
 
-    /* Remove a single Goal from the user's collection */
     public void removeGoal(Goal goal) {
-        mGoals.remove(goal);
-
-        // Remove the goal from its parent categories
-        for(Category category : mCategories) {
-            category.removeGoal(goal);
-        }
-
-        logSelectedData("AFTER CompassApplication.removeGoal: " + goal.getTitle());
-    }
-
-    /**
-     * Goals are associated with one or more categories. This method will include
-     * the user's selected goals within their selected Categories.
-     */
-    public void assignGoalsToCategories() {
-        // add each goal to the correct category
-        for (Category category : getCategories()) {
-            ArrayList<Goal> categoryGoals = new ArrayList<Goal>();
-            for (Goal goal : getGoals()) {
-                for (Category goalCategory : goal.getCategories()) {
-                    if (goalCategory.getId() == category.getId()) {
-                        categoryGoals.add(goal);
-                        break;
-                    }
-                }
-            }
-            category.setGoals(categoryGoals);
-        }
+        mUserData.removeGoal(goal);
     }
 
     public void setBehaviors(ArrayList<Behavior> behaviors) {
-        mBehaviors = behaviors;
-        for(Behavior b: behaviors) {
-            Log.d(TAG, "--> setBehavior: " + b.getTitle());
-        }
-        assignBehaviorsToGoals();
-        logSelectedData("AFTER CompassApplication.setBehaviors");
+        mUserData.setBehaviors(behaviors);
+        mUserData.logSelectedData("AFTER CompassApplication.setBehaviors");
     }
 
     public ArrayList<Behavior> getBehaviors() {
-        return mBehaviors;
+        return mUserData.getBehaviors();
     }
 
-    /* Remove a single Behavior from a user's collection */
     public void removeBehavior(Behavior behavior) {
-        mBehaviors.remove(behavior);
-
-        // Remove the behavior from any Goals
-        for(Goal goal : getGoals()) {
-            goal.removeBehavior(behavior);
-        }
-        logSelectedData("AFTER CompassApplication.removeBehavior: " + behavior.getTitle());
+        mUserData.removeBehavior(behavior);
+        mUserData.logSelectedData("AFTER CompassApplication.removeBehavior: " + behavior.getTitle());
     }
 
     public void addBehavior(Behavior behavior) {
-        if(!mBehaviors.contains(behavior)) {
-            mBehaviors.add(behavior);
-            assignBehaviorsToGoals();
-            logSelectedData("AFTER CompassApplication.addBehavior: " + behavior.getTitle());
-        }
-    }
-
-    /** Behaviors are contained within a Goal. This method will take the list
-     * of selected behaviors, and associate them with the user's selected goals.
-     */
-    public void assignBehaviorsToGoals() {
-        for (Goal goal : getGoals()) { // Look at all the selected goals
-            ArrayList<Behavior> goalBehaviors = new ArrayList<Behavior>();
-            for (Behavior behavior : getBehaviors()) { // look at all the selected behaviors...
-                for (Goal behaviorGoal : behavior.getGoals()) { // The Behavior's Parent goals
-                    if (behaviorGoal.getId() == goal.getId()) {
-                        goalBehaviors.add(behavior);
-                        break;
-                    }
-                }
-            }
-            goal.setBehaviors(goalBehaviors);
-        }
+        mUserData.addBehavior(behavior);
     }
 
     public ArrayList<Action> getActions() {
-        return mActions;
+        return mUserData.getActions();
     }
 
-    /* Remove a single Action from a user's collection */
     public void removeAction(Action action) {
-        mActions.remove(action);
-
-        // Remove the action from any related behaviors
-        for(Behavior behavior : mBehaviors) {
-            behavior.removeAction(action);
-        }
-
-        logSelectedData("AFTER CompassApplication.removeAction: " + action.getTitle());
+        mUserData.removeAction(action);
+        mUserData.logSelectedData("AFTER CompassApplication.removeAction: " + action.getTitle());
     }
 
     public void setActions(ArrayList<Action> actions) {
-        mActions = actions;
-        for(Action a: actions) {
-            Log.d(TAG, "--> setAction: " + a.getTitle());
-        }
-        assignActionsToBehaviors();
-        logSelectedData("AFTER CompassApplication.setActions");
+        mUserData.setActions(actions);
+        mUserData.logSelectedData("AFTER CompassApplication.setActions");
     }
 
-    /* Add an individual action the user's collection */
     public void addAction(Action action) {
-        if(!mActions.contains(action)) {
-            mActions.add(action);
-            assignActionsToBehaviors();
-            logSelectedData("AFTER CompassApplication.addAction: " + action.getTitle());
-        }
+        mUserData.addAction(action);
     }
 
-    /* update a single Action in a user's collection */
     public void updateAction(Action action) {
-        // Given a single action, find it in the list of Actions and keep the input version
-        int i = 0;
-        boolean found = false;
-        for (Action a : mActions) {
-            if(a.getId() == action.getId()) {
-                found = true;
-                break;
-            }
-            i++;
-        }
-        if(found) {
-            // remove the old action
-            mActions.remove(i);
-        }
-        mActions.add(action);
-    }
-
-    /** Actions are contained within a single Behavior. This method will take the list
-     * of selected actions, and associate them with the user's selected behaviors.
-     */
-    public void assignActionsToBehaviors() {
-
-        for (Behavior behavior : getBehaviors()) {
-            ArrayList<Action> behaviorActions = new ArrayList<Action>();
-            for (Action action : getActions()) {
-                if (behavior.getId() == action.getBehavior_id()) {
-                    behaviorActions.add(action);
-                    break;
-                }
-            }
-            behavior.setActions(behaviorActions);
-        }
-
-        // now, set each Action's parent Behavior.
-        setActionParents();
-    }
-
-    /**
-    * This method will set the Behavior attribute for all of the user's selected Actions, so the
-    * Action will contain a reference to its parent.
-    */
-    public void setActionParents() {
-        // set a reference to the parent for each action.
-        for(Action action : getActions()) {
-            for(Behavior behavior : getBehaviors()) {
-                if(action.getBehavior_id() == behavior.getId()) {
-                    action.setBehavior(behavior);
-                }
-            }
-        }
-    }
-
-    public void logSelectedGoalData(String title) {
-        // Log user-selected goals, behaviors, actions
-        Log.d(TAG, "------------- " + title + " --------------- ");
-        for(Goal g : getGoals()) {
-            Log.d(TAG, "-- GOAL --> " + g.getTitle());
-            for(Behavior b : g.getBehaviors()) {
-                Log.d(TAG, "---- Behavior --> " + b.getTitle());
-                for(Action a : b.getActions()) {
-                    Log.d(TAG, "------ Action --> " + a.getTitle());
-                }
-            }
-        }
-    }
-
-    public void logSelectedData(String title) {
-        // Log user-selected categories, goals, behaviors, actions
-        Log.d(TAG, "------------- " + title + " --------------- ");
-        for(Category c : getCategories()) {
-            Log.d(TAG, "CATEGORY --> " + c.getTitle());
-            for (Goal g : c.getGoals()) {
-                Log.d(TAG, "-- GOAL --> " + g.getTitle());
-                for (Behavior b : g.getBehaviors()) {
-                    Log.d(TAG, "---- BEHAVIOR --> " + b.getTitle());
-                    for (Action a : b.getActions()) {
-                        Log.d(TAG, "------ ACTION --> " + a.getTitle());
-                    }
-                }
-            }
-        }
-        Log.d(TAG, "------------------------------------------- ");
+        mUserData.updateAction(action);
     }
 
     @Override

--- a/src/main/java/org/tndata/android/compass/activity/GoalTryActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/GoalTryActivity.java
@@ -429,7 +429,6 @@ public class GoalTryActivity extends ActionBarActivity implements
     @Override
     public void behaviorsDeleted() {
         Log.d("GoalTryActivity", "DeleteBehaviorTask completed.");
-        application.logSelectedData("AFTER Deleting a Behavior");
         mAdapter.notifyDataSetChanged();
     }
 

--- a/src/main/java/org/tndata/android/compass/activity/MainActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/MainActivity.java
@@ -11,7 +11,6 @@ import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarActivity;
 import android.support.v7.app.ActionBarDrawerToggle;
 import android.support.v7.widget.Toolbar;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.MenuItem;
 import android.view.View;
@@ -27,19 +26,10 @@ import org.tndata.android.compass.adapter.DrawerAdapter;
 import org.tndata.android.compass.adapter.MainViewPagerAdapter;
 import org.tndata.android.compass.fragment.CategoryFragment.CategoryFragmentListener;
 import org.tndata.android.compass.fragment.MyGoalsFragment.MyGoalsFragmentListener;
-import org.tndata.android.compass.model.Action;
-import org.tndata.android.compass.model.Behavior;
 import org.tndata.android.compass.model.Category;
 import org.tndata.android.compass.model.DrawerItem;
-import org.tndata.android.compass.model.Goal;
-import org.tndata.android.compass.task.GetUserActionsTask;
-import org.tndata.android.compass.task.GetUserActionsTask.GetUserActionsListener;
-import org.tndata.android.compass.task.GetUserBehaviorsTask;
-import org.tndata.android.compass.task.GetUserBehaviorsTask.GetUserBehaviorsListener;
-import org.tndata.android.compass.task.GetUserCategoriesTask;
-import org.tndata.android.compass.task.GetUserCategoriesTask.GetUserCategoriesListener;
-import org.tndata.android.compass.task.GetUserGoalsTask;
-import org.tndata.android.compass.task.GetUserGoalsTask.GetUserGoalsListener;
+import org.tndata.android.compass.model.UserData;
+import org.tndata.android.compass.task.GetUserDataTask;
 import org.tndata.android.compass.task.UpdateProfileTask;
 import org.tndata.android.compass.util.Constants;
 import org.tndata.android.compass.util.GcmRegistration;
@@ -47,9 +37,14 @@ import org.tndata.android.compass.util.ImageLoader;
 
 import java.util.ArrayList;
 
+
+// TODO: remove the different GetUserWHATEVERListeners, and incorporate the GetUserDataTask;
+// todo: we want a single api request to populate the user's selected information.
+// TODO: clean up commented-out assignGoalsToCategories in MyGoalsFragment and CategoryFragment.
+
 public class MainActivity extends ActionBarActivity implements
-        GetUserCategoriesListener, GetUserGoalsListener, GetUserBehaviorsListener,
-        GetUserActionsListener, MyGoalsFragmentListener, CategoryFragmentListener {
+        GetUserDataTask.GetUserDataListener, MyGoalsFragmentListener, CategoryFragmentListener {
+
     private static final int IMPORTANT_TO_ME = 0;
     private static final int MY_PRIORITIES = 1;
     private static final int MYSELF = 2;
@@ -99,6 +94,10 @@ public class MainActivity extends ActionBarActivity implements
         setContentView(R.layout.activity_main);
 
         application = (CompassApplication) getApplication();
+
+        // Load all user-selected content from the API
+        new GetUserDataTask(this).executeOnExecutor(
+                AsyncTask.THREAD_POOL_EXECUTOR, application.getToken());
 
         //Update the timezone
         new UpdateProfileTask(null).execute(application.getUser());
@@ -187,25 +186,25 @@ public class MainActivity extends ActionBarActivity implements
     public void showCategories() {
         ArrayList<Category> categories = application.getCategories();
 
-        if (!fetchedCategories && (categories == null || categories.isEmpty())) {
-            new GetUserCategoriesTask(this).executeOnExecutor(
-                    AsyncTask.THREAD_POOL_EXECUTOR, application.getToken());
-        } else if(categories != null) {
+//        if (!fetchedCategories && (categories == null || categories.isEmpty())) {
+//            new GetUserCategoriesTask(this).executeOnExecutor(
+//                    AsyncTask.THREAD_POOL_EXECUTOR, application.getToken());
+//        } else if(categories != null) {
             mAdapter.setCategories(application.getCategories());
             showGoals();
 
             mAdapter.notifyDataSetChanged();
-        }
+//        }
     }
 
     public void showGoals() {
-        if (application.getGoals().isEmpty()) {
-            new GetUserGoalsTask(this).executeOnExecutor(
-                    AsyncTask.THREAD_POOL_EXECUTOR, application.getToken());
-        } else {
+//        if (application.getGoals().isEmpty()) {
+//            new GetUserGoalsTask(this).executeOnExecutor(
+//                    AsyncTask.THREAD_POOL_EXECUTOR, application.getToken());
+//        } else {
             Intent intent = new Intent(Constants.GOAL_UPDATED_BROADCAST_ACTION);
             sendBroadcast(intent);
-        }
+//        }
     }
 
     protected class DrawerItemClickListener implements
@@ -333,53 +332,59 @@ public class MainActivity extends ActionBarActivity implements
     }
 
     @Override
-    public void categoriesLoaded(ArrayList<Category> categories) {
-        application.setCategories(categories);
-        showCategories();
-        fetchedCategories = true;
+    public void userDataLoaded(UserData userData) {
+        application.setUserData(userData);
     }
 
-    @Override
-    public void goalsLoaded(ArrayList<Goal> goals) {
-        application.setGoals(goals);
-        new GetUserBehaviorsTask(this).executeOnExecutor(
-                AsyncTask.THREAD_POOL_EXECUTOR, application.getToken());
-        new GetUserActionsTask(this).executeOnExecutor(
-                AsyncTask.THREAD_POOL_EXECUTOR, application.getToken());
-    }
+//    @Override
+//    public void categoriesLoaded(ArrayList<Category> categories) {
+//        application.setCategories(categories);
+//        showCategories();
+//        fetchedCategories = true;
+//    }
 
-    @Override
-    public void behaviorsLoaded(ArrayList<Behavior> behaviors) {
-        if (behaviors != null) {
-            // Save the user's selected behaviors
-            application.setBehaviors(behaviors);
-            behaviorsLoadedDone = true;
-        }
-        assignGoalsToCategories(false);
-        showGoals();
-        if(behaviorsLoadedDone && actionsLoadedDone) {
-            application.assignActionsToBehaviors();
-        }
-    }
+//    @Override
+//    public void goalsLoaded(ArrayList<Goal> goals) {
+//        application.setGoals(goals);
+//        new GetUserBehaviorsTask(this).executeOnExecutor(
+//                AsyncTask.THREAD_POOL_EXECUTOR, application.getToken());
+//        new GetUserActionsTask(this).executeOnExecutor(
+//                AsyncTask.THREAD_POOL_EXECUTOR, application.getToken());
+//    }
+//
+//    @Override
+//    public void behaviorsLoaded(ArrayList<Behavior> behaviors) {
+//        if (behaviors != null) {
+//            // Save the user's selected behaviors
+//            application.setBehaviors(behaviors);
+//            behaviorsLoadedDone = true;
+//        }
+//        assignGoalsToCategories(false);
+//        showGoals();
+////        if(behaviorsLoadedDone && actionsLoadedDone) {
+////            application.assignActionsToBehaviors();
+////        }
+//    }
 
-    @Override
-    public void actionsLoaded(ArrayList<Action> actions) {
-        application.setActions(actions);
-        actionsLoadedDone = true;
-        if(behaviorsLoadedDone && actionsLoadedDone) {
-            application.assignActionsToBehaviors();
-        }
-    }
+//    @Override
+//    public void actionsLoaded(ArrayList<Action> actions) {
+//        application.setActions(actions);
+//        actionsLoadedDone = true;
+////        if(behaviorsLoadedDone && actionsLoadedDone) {
+////            application.assignActionsToBehaviors();
+////        }
+//    }
 
-    @Override
-    public void assignGoalsToCategories(boolean shouldSendBroadcast) {
-        application.assignGoalsToCategories();
-        if (shouldSendBroadcast) {
-            Intent intent = new Intent(Constants.GOAL_UPDATED_BROADCAST_ACTION);
-            sendBroadcast(intent);
-            Log.d("Main Activity", "send broadcast");
-        }
-    }
+//    @Override
+//    public void assignGoalsToCategories(boolean shouldSendBroadcast) {
+//        // TODO: need to update the MyGoalsFragment & CategoryFragment? no need to call this anymore?
+//        application.assignGoalsToCategories();
+//        if (shouldSendBroadcast) {
+//            Intent intent = new Intent(Constants.GOAL_UPDATED_BROADCAST_ACTION);
+//            sendBroadcast(intent);
+//            Log.d("Main Activity", "send broadcast");
+//        }
+//    }
 
     public void activateTab(int tabIndex) {
         mViewPager.setCurrentItem(tabIndex);

--- a/src/main/java/org/tndata/android/compass/fragment/CategoryFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/CategoryFragment.java
@@ -62,7 +62,7 @@ public class CategoryFragment extends Fragment implements
     };
 
     public interface CategoryFragmentListener {
-        public void assignGoalsToCategories(boolean shouldSendBroadcast);
+//        public void assignGoalsToCategories(boolean shouldSendBroadcast);
     }
 
     public static CategoryFragment newInstance(Category category) {
@@ -185,7 +185,7 @@ public class CategoryFragment extends Fragment implements
         if (requestCode == Constants.CHOOSE_GOALS_REQUEST_CODE ||
                 requestCode == Constants.BEHAVIOR_CHANGED_RESULT_CODE ||
                 requestCode == Constants.GOALS_CHANGED_RESULT_CODE) {
-            mCallback.assignGoalsToCategories(true);
+//            mCallback.assignGoalsToCategories(true);
         }
     }
 

--- a/src/main/java/org/tndata/android/compass/fragment/CategoryFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/CategoryFragment.java
@@ -1,6 +1,5 @@
 package org.tndata.android.compass.fragment;
 
-import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -49,8 +48,6 @@ public class CategoryFragment extends Fragment implements
     private CategoryFragmentAdapter mAdapter;
     private ArrayList<Goal> mItems = new ArrayList<Goal>();
     private boolean mBroadcastIsRegistered = false;
-    private CategoryFragmentListener mCallback;
-    
     private static final String TAG = "CategoryFragment";
 
     private BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
@@ -60,10 +57,6 @@ public class CategoryFragment extends Fragment implements
             categoryGoalsUpdated();
         }
     };
-
-    public interface CategoryFragmentListener {
-//        public void assignGoalsToCategories(boolean shouldSendBroadcast);
-    }
 
     public static CategoryFragment newInstance(Category category) {
         CategoryFragment fragment = new CategoryFragment();
@@ -132,25 +125,6 @@ public class CategoryFragment extends Fragment implements
         super.onDestroy();
     }
 
-    @Override
-    public void onAttach(Activity activity) {
-        super.onAttach(activity); // This makes sure that the container activity
-        // has implemented the callback interface. If not, it throws an
-        // exception
-        try {
-            mCallback = (CategoryFragmentListener) activity;
-        } catch (ClassCastException e) {
-            throw new ClassCastException(activity.toString()
-                    + " must implement CategoryFragmentListener");
-        }
-    }
-
-    @Override
-    public void onDetach() {
-        super.onDetach();
-        mCallback = null;
-    }
-
     private void registerReceivers() {
         if (mBroadcastIsRegistered == false) {
             getActivity().getApplicationContext().registerReceiver(broadcastReceiver,
@@ -177,16 +151,6 @@ public class CategoryFragment extends Fragment implements
         intent.putExtra("category", mCategory);
         startActivityForResult(intent, Constants.CHOOSE_GOALS_REQUEST_CODE);
         mAdapter.notifyDataSetChanged();
-    }
-
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        Log.d(TAG, "onActivityResult");
-        if (requestCode == Constants.CHOOSE_GOALS_REQUEST_CODE ||
-                requestCode == Constants.BEHAVIOR_CHANGED_RESULT_CODE ||
-                requestCode == Constants.GOALS_CHANGED_RESULT_CODE) {
-//            mCallback.assignGoalsToCategories(true);
-        }
     }
 
     public void categoryGoalsUpdated() {

--- a/src/main/java/org/tndata/android/compass/fragment/CategoryFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/CategoryFragment.java
@@ -116,7 +116,6 @@ public class CategoryFragment extends Fragment implements
     public void onResume() {
         super.onResume();
         mAdapter.notifyDataSetChanged();
-        application.logSelectedData("CategoryFragment.onResume");
     }
 
     @Override

--- a/src/main/java/org/tndata/android/compass/fragment/MyGoalsFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/MyGoalsFragment.java
@@ -46,7 +46,7 @@ public class MyGoalsFragment extends Fragment implements SurveyFinderTask.Survey
     public interface MyGoalsFragmentListener {
         public void chooseCategories();
 
-        public void assignGoalsToCategories(boolean shouldSendBroadcast);
+//        public void assignGoalsToCategories(boolean shouldSendBroadcast);
 
         public void transitionToCategoryTab(Category category);
     }
@@ -261,9 +261,9 @@ public class MyGoalsFragment extends Fragment implements SurveyFinderTask.Survey
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == Constants.CHOOSE_GOALS_REQUEST_CODE) {
-            mCallback.assignGoalsToCategories(true);
-        }
+//        if (requestCode == Constants.CHOOSE_GOALS_REQUEST_CODE) {
+//            mCallback.assignGoalsToCategories(true);
+//        }
     }
 
     @Override

--- a/src/main/java/org/tndata/android/compass/fragment/MyGoalsFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/MyGoalsFragment.java
@@ -46,8 +46,6 @@ public class MyGoalsFragment extends Fragment implements SurveyFinderTask.Survey
     public interface MyGoalsFragmentListener {
         public void chooseCategories();
 
-//        public void assignGoalsToCategories(boolean shouldSendBroadcast);
-
         public void transitionToCategoryTab(Category category);
     }
 
@@ -257,13 +255,6 @@ public class MyGoalsFragment extends Fragment implements SurveyFinderTask.Survey
         intent.putExtra("goal", goal);
         intent.putExtra("category", category);
         startActivity(intent);
-    }
-
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-//        if (requestCode == Constants.CHOOSE_GOALS_REQUEST_CODE) {
-//            mCallback.assignGoalsToCategories(true);
-//        }
     }
 
     @Override

--- a/src/main/java/org/tndata/android/compass/model/UserData.java
+++ b/src/main/java/org/tndata/android/compass/model/UserData.java
@@ -54,8 +54,15 @@ public class UserData {
      * @param categories
      */
     public void setCategories(ArrayList<Category> categories) {
+        setCategories(categories, true);
+    }
+
+    public void setCategories(ArrayList<Category> categories, boolean sync) {
         if(categories != null && !categories.isEmpty()) {
             mCategories = categories;
+        }
+        if(sync) {
+            assignGoalsToCategories();
         }
     }
 
@@ -115,8 +122,14 @@ public class UserData {
      * @param goals an ArrayList of Goal objects
      */
     public void setGoals(ArrayList<Goal> goals) {
+        setGoals(goals, true);
+    }
+
+    public void setGoals(ArrayList<Goal> goals, boolean sync) {
         mGoals = goals;
-        assignGoalsToCategories();
+        if(sync) {
+            assignGoalsToCategories();
+        }
     }
 
     /**
@@ -193,8 +206,13 @@ public class UserData {
      * @param behaviors an ArrayList of Behavior objects
      */
     public void setBehaviors(ArrayList<Behavior> behaviors) {
+        setBehaviors(behaviors, true);
+    }
+    public void setBehaviors(ArrayList<Behavior> behaviors, boolean sync) {
         mBehaviors = behaviors;
-        assignBehaviorsToGoals();
+        if(sync) {
+            assignBehaviorsToGoals();
+        }
     }
 
     /**
@@ -272,8 +290,13 @@ public class UserData {
      * @param actions
      */
     public void setActions(ArrayList<Action> actions) {
+        setActions(actions, true);
+    }
+    public void setActions(ArrayList<Action> actions, boolean sync) {
         mActions = actions;
-        assignActionsToBehaviors();
+        if(sync) {
+            assignActionsToBehaviors();
+        }
     }
 
     /**
@@ -376,6 +399,27 @@ public class UserData {
 
     ----------------------------------------------------------------- */
 
+    /**
+     * Log the value of individual private data members.
+     */
+    public void logData() {
+        Log.d(TAG, "Categories.");
+        for(Category item : mCategories) {
+            Log.d(TAG, "- (" + item.getId() + ") " + item.getTitle());
+        }
+        Log.d(TAG, "Goals.");
+        for(Goal item : mGoals) {
+            Log.d(TAG, "- (" + item.getId() + ") " + item.getTitle());
+        }
+        Log.d(TAG, "Behaviors.");
+        for(Behavior item : mBehaviors) {
+            Log.d(TAG, "- (" + item.getId() + ") " + item.getTitle());
+        }
+        Log.d(TAG, "Actions.");
+        for(Action item : mActions) {
+            Log.d(TAG, "- (" + item.getId() + ") " + item.getTitle());
+        }
+    }
     /**
      * Given a goal, Log information for it's parent Categories.
      *

--- a/src/main/java/org/tndata/android/compass/model/UserData.java
+++ b/src/main/java/org/tndata/android/compass/model/UserData.java
@@ -406,18 +406,24 @@ public class UserData {
         Log.d(TAG, "Categories.");
         for(Category item : mCategories) {
             Log.d(TAG, "- (" + item.getId() + ") " + item.getTitle());
+            Log.d(TAG, "--> contains " + item.getGoals().size() + " goals");
         }
         Log.d(TAG, "Goals.");
         for(Goal item : mGoals) {
             Log.d(TAG, "- (" + item.getId() + ") " + item.getTitle());
+            Log.d(TAG, "--> contains " + item.getCategories().size() + " categories");
+            Log.d(TAG, "--> contains " + item.getBehaviors().size() + " behaviors");
         }
         Log.d(TAG, "Behaviors.");
         for(Behavior item : mBehaviors) {
             Log.d(TAG, "- (" + item.getId() + ") " + item.getTitle());
+            Log.d(TAG, "--> contains " + item.getGoals().size() + " goals");
+            Log.d(TAG, "--> contains " + item.getActions().size() + " actions");
         }
         Log.d(TAG, "Actions.");
         for(Action item : mActions) {
             Log.d(TAG, "- (" + item.getId() + ") " + item.getTitle());
+            Log.d(TAG, "--> contains, behavior_id = " + item.getBehavior_id());
         }
     }
     /**

--- a/src/main/java/org/tndata/android/compass/model/UserData.java
+++ b/src/main/java/org/tndata/android/compass/model/UserData.java
@@ -1,0 +1,468 @@
+package org.tndata.android.compass.model;
+
+import android.util.Log;
+
+import java.util.ArrayList;
+
+/**
+ * Created by brad on 07/22/2015.
+ *
+ * This class encapsulates all of the user-selected content from the online REST api:
+ *
+ * - Categories
+ * - Goals
+ * - Behaviors
+ * - Actions
+ *
+ * It includes methods to set & get those values, and keeps a consistently updated
+ * hierarchy (i.e. Behaviors know about their parent goals & child actions, etc).
+ *
+ */
+public class UserData {
+
+    private static final String TAG = "UserData";
+    private ArrayList<Category> mCategories = new ArrayList<Category>(); // The user's selected Categories
+    private ArrayList<Goal> mGoals = new ArrayList<Goal>();  // The user's selected Goals
+    private ArrayList<Behavior> mBehaviors = new ArrayList<Behavior>(); // The user's selected behaviors
+    private ArrayList<Action> mActions = new ArrayList<Action>(); // The user's selected actions
+
+    public UserData() {
+    }
+
+    /**
+     * Sync up all parent/child objects.
+     */
+    public void sync() {
+        assignGoalsToCategories();
+        assignBehaviorsToGoals();
+        assignActionsToBehaviors();
+        setActionParents();
+    }
+
+    /**
+     * Returns the list of user-selected Categories.
+     *
+     * @return an ArrayList of Category objects
+     */
+    public ArrayList<Category> getCategories() {
+        return mCategories;
+    }
+
+    /**
+     * Initialize a list of user-selected Categories.
+     *
+     * @param categories
+     */
+    public void setCategories(ArrayList<Category> categories) {
+        if(categories != null && !categories.isEmpty()) {
+            mCategories = categories;
+        }
+    }
+
+    /**
+     * Adds a Category to the list of user-selected categories (if it's not
+     * already included).
+     *
+     * Adding a Category also assigns any user-selected goals to the new Category.
+     *
+     * @param category the Category object to add.
+     */
+    public void addCategory(Category category) {
+        if(!mCategories.contains(category)) {
+            mCategories.add(category);
+            assignGoalsToCategories();
+        }
+    }
+
+    /**
+     * Remove a single Category from the user's collection. This also removes the
+     * reference to that category from all Goals.
+     *
+     * @param category the category to remove
+     */
+    public void removeCategory(Category category) {
+        mCategories.remove(category);
+
+        // also remove this category from any child goals
+        for(Goal goal : mGoals) {
+            goal.removeCategory(category);
+        }
+    }
+
+    /**
+     * Returns all of the goals for a given Category.This is a wrapper for category.getGoals();
+     *
+     * @return an ArrayList of Goal objects.
+     */
+    public ArrayList<Goal> getCategoryGoals(Category category) {
+        return category.getGoals();
+    }
+
+
+    /**
+     * Returns the list of user-selected Goals.
+     *
+     * @return an ArrayList of Goal objects.
+     */
+    public ArrayList<Goal> getGoals() {
+        return mGoals;
+    }
+
+    /**
+     * Initialize the list of user-selected Goals. Setting this value also updates the
+     * list of user-selected Categories, so they contain references to valid child goals.
+     *
+     * @param goals an ArrayList of Goal objects
+     */
+    public void setGoals(ArrayList<Goal> goals) {
+        mGoals = goals;
+        assignGoalsToCategories();
+    }
+
+    /**
+     * Goals are associated with one or more categories. This method will include
+     * the user's selected goals within their selected Categories.
+     */
+    public void assignGoalsToCategories() {
+        // add each goal to the correct category
+        for (Category category : getCategories()) {
+            ArrayList<Goal> categoryGoals = new ArrayList<Goal>();
+            for (Goal goal : getGoals()) {
+                for (Category goalCategory : goal.getCategories()) {
+                    if (goalCategory.getId() == category.getId()) {
+                        categoryGoals.add(goal);
+                        break;
+                    }
+                }
+            }
+            category.setGoals(categoryGoals);
+        }
+    }
+
+    /**
+     * Add a goal to the list of user-selected Goals.
+     *
+     * Adding a Goal also assigns it to any existing user-selected categories,
+     * as well as assigning any existing Behaviors to the Goal.
+     *
+     * @param goal
+     */
+    public void addGoal(Goal goal) {
+        if(!mGoals.contains(goal)) {
+            mGoals.add(goal);
+            assignGoalsToCategories();
+            assignBehaviorsToGoals();
+        }
+    }
+
+    /**
+     * Removes a goal from the user's collection.
+     *
+     * Removing a goal also removes its reference from the parent Categories
+     * as well as the child Behaviors.
+     *
+     * @param goal
+     */
+    public void removeGoal(Goal goal) {
+        mGoals.remove(goal);
+
+        // Remove the goal from its parent categories
+        for(Category category : mCategories) {
+            category.removeGoal(goal);
+        }
+
+        // Remove the goal from it's child Behaviors.
+        for(Behavior behavior : mBehaviors) {
+            behavior.removeGoal(goal);
+        }
+    }
+
+    /**
+     * Return the user-selected Behaviors.
+     *
+     * @return an ArrayList of Behavior objects.
+     */
+    public ArrayList<Behavior> getBehaviors() {
+        return mBehaviors;
+    }
+
+    /**
+     * Initialize the list of user-selected Behaviors. Setting this value also updates the
+     * list of user-selected Goals, so they contain references to valid child behaviors.
+     *
+     * @param behaviors an ArrayList of Behavior objects
+     */
+    public void setBehaviors(ArrayList<Behavior> behaviors) {
+        mBehaviors = behaviors;
+        assignBehaviorsToGoals();
+    }
+
+    /**
+     * Remove a single Behavior from a user's collection. Doing this will also remove any
+     * references to the Behavior from the parent Goal, and it will also remove the
+     * child Actions.
+     *
+     * @param behavior the Behavior instance to remove.
+     */
+    public void removeBehavior(Behavior behavior) {
+        mBehaviors.remove(behavior);
+
+        // Remove the behavior from any parent Goals
+        for(Goal goal : getGoals()) {
+            goal.removeBehavior(behavior);
+        }
+
+        // Remove the child Actions
+        ArrayList<Action> toRemove = new ArrayList<Action>();
+        for(Action action: getActions()) {
+            if(action.getBehavior_id() == behavior.getId()) {
+                toRemove.add(action);
+            }
+        }
+        mActions.removeAll(toRemove);
+    }
+
+    /**
+     * Add a single Behavior to the user's collection.
+     *
+     * Adding this object will also trigger an update to behavior's parent goals.
+     *
+     * @param behavior
+     */
+    public void addBehavior(Behavior behavior) {
+        if(!mBehaviors.contains(behavior)) {
+            mBehaviors.add(behavior);
+            assignBehaviorsToGoals();
+        }
+    }
+
+    /** Behaviors are contained within a Goal. This method will take the list
+     * of selected behaviors, and associate them with the user's selected goals.
+     */
+    public void assignBehaviorsToGoals() {
+        for (Goal goal : getGoals()) { // Look at all the selected goals
+            ArrayList<Behavior> goalBehaviors = new ArrayList<Behavior>();
+            for (Behavior behavior : getBehaviors()) { // look at all the selected behaviors...
+                for (Goal behaviorGoal : behavior.getGoals()) { // The Behavior's Parent goals
+                    if (behaviorGoal.getId() == goal.getId()) {
+                        goalBehaviors.add(behavior);
+                        break;
+                    }
+                }
+            }
+            goal.setBehaviors(goalBehaviors);
+        }
+    }
+
+    /**
+     * Retrieve a list of all user-selected Actions.
+     *
+     * @return an ArrayList of Action objects.
+     */
+    public ArrayList<Action> getActions() {
+        return mActions;
+    }
+
+    /**
+     * Initialize the list of user-selected Actions.
+     *
+     * Setting this triggers an update, which will associate all user-selected actions
+     * with their parent in the collection of user-selected Behaviors.
+     *
+     * @param actions
+     */
+    public void setActions(ArrayList<Action> actions) {
+        mActions = actions;
+        assignActionsToBehaviors();
+    }
+
+    /**
+     * Remove a single Action from a user's collection. Doing this will also remove
+     * any reference to that Action from it's parent Behaviors.
+     *
+     * @param action the Action object to remove.
+     */
+    public void removeAction(Action action) {
+        mActions.remove(action);
+
+        // Remove the action from any related behaviors
+        for(Behavior behavior : mBehaviors) {
+            behavior.removeAction(action);
+        }
+    }
+
+    /**
+     *  Add an individual action the user's collection. Adding an action will also
+     *  update the user's selected Behaviors, including a reference to the new
+     *  action within any relevant parent Behavior.
+     *
+     * @param action
+     */
+    public void addAction(Action action) {
+        if(!mActions.contains(action)) {
+            mActions.add(action);
+            assignActionsToBehaviors();
+        }
+    }
+
+    /**
+     * Update a single Action in a user's collection; When some Action has been changed
+     * (e.g. it's custom-trigger updated), this method will replace stale instances of
+     * the Action with the new version.
+     *
+     * Updating an Action will also trigger an update to the parent behaviors.
+     *
+     * @param action the Action object to update.
+     */
+    public void updateAction(Action action) {
+        // Given a single action, find it in the list of Actions and keep the input version
+        int i = 0;
+        boolean found = false;
+        for (Action a : mActions) {
+            if(a.getId() == action.getId()) {
+                found = true;
+                break;
+            }
+            i++;
+        }
+        if(found) {
+            // remove the old action
+            removeAction(mActions.get(i));
+        }
+        mActions.add(action);
+        assignActionsToBehaviors();
+    }
+
+    /** Actions are contained within a single Behavior. This method will take the list
+     * of selected actions, and associate them with the user-selected behaviors.
+     *
+     * This ensures that all behaviors have a valid reference to their child Actions.
+     */
+    public void assignActionsToBehaviors() {
+
+        for (Behavior behavior : getBehaviors()) {
+            ArrayList<Action> behaviorActions = new ArrayList<Action>();
+            for (Action action : getActions()) {
+                if (behavior.getId() == action.getBehavior_id()) {
+                    behaviorActions.add(action);
+                    break;
+                }
+            }
+            behavior.setActions(behaviorActions);
+        }
+
+        // now, set each Action's parent Behavior.
+        setActionParents();
+    }
+
+    /**
+     * This method will set the Behavior attribute for all of the user's selected Actions, so the
+     * Action will contain a valid reference to its parent.
+     */
+    public void setActionParents() {
+        // set a reference to the parent for each action.
+        for(Action action : getActions()) {
+            for(Behavior behavior : getBehaviors()) {
+                if(action.getBehavior_id() == behavior.getId()) {
+                    action.setBehavior(behavior);
+                }
+            }
+        }
+    }
+
+    /* -----------------------------------------------------------------
+
+    The following are data logging methods; useful for debugging.
+
+    ----------------------------------------------------------------- */
+
+    /**
+     * Given a goal, Log information for it's parent Categories.
+     *
+     * @param goal
+     */
+    public void logParentCategories(Goal goal) {
+        String output = "NONE";
+        if(!goal.getCategories().isEmpty()) {
+            output = "";
+            for(Category c : goal.getCategories()) {
+                output += "(" + c.getId() + ") " + c.getTitle() + ", ";
+            }
+        }
+        Log.d(TAG, "- (parents) -> " + output);
+    }
+
+    /**
+     * Given a behavior, log information for it's parent Goals.
+     *
+     * @param behavior
+     */
+    public void logParentGoals(Behavior behavior) {
+        String output = "NONE";
+        if(!behavior.getGoals().isEmpty()) {
+            output = "";
+            for(Goal g : behavior.getGoals()) {
+                output += "(" + g.getId() + ") " + g.getTitle() + ", ";
+            }
+        }
+        Log.d(TAG, "-- (parents) ->" + output);
+    }
+
+    /**
+     * Given an Action, log information for it's parent Behavior
+     * @param action
+     */
+    public void logParentBehavior(Action action) {
+        String output = "NONE";
+        if(action.getBehavior() != null) {
+            output = "(" + action.getBehavior().getId() + ") " + action.getBehavior().getTitle();
+        }
+        Log.d(TAG, "--- (parent)-> " + output);
+    }
+
+    /**
+     * Log the hierarchy of all User-selected data.
+     */
+    public void logSelectedData() {
+        logSelectedData("User Data");
+    }
+
+    /**
+     * Log the hierarchy of all User-selected data, with a custom title.
+     *
+     * @param title a custom title to display above the output.
+     *
+     */
+    public void logSelectedData(String title) {
+        logSelectedData(title, true);
+    }
+
+    /**
+     * Log the hierarchy of all User-selected data, with a custom title, and an option to
+     * include each level's parent data.
+     *
+     * @param title a custom title to display above the output.
+     * @param include_parents if true, will Log each item's parent objects.
+     *
+     */
+    public void logSelectedData(String title, boolean include_parents) {
+        // Log user-selected categories, goals, behaviors, actions
+        Log.d(TAG, "------------- " + title + " --------------- ");
+        for(Category c : getCategories()) {
+            Log.d(TAG, "CATEGORY: " + c.getTitle());
+            for (Goal g : c.getGoals()) {
+                Log.d(TAG, "- GOAL: " + g.getTitle());
+                if(include_parents) {logParentCategories(g);}
+                for (Behavior b : g.getBehaviors()) {
+                    Log.d(TAG, "-- BEHAVIOR: " + b.getTitle());
+                    if(include_parents) {logParentGoals(b);}
+                    for (Action a : b.getActions()) {
+                        Log.d(TAG, "--- ACTION: " + a.getTitle());
+                        if(include_parents) {logParentBehavior(a);}
+                    }
+                }
+            }
+        }
+        Log.d(TAG, "------------------------------------------- ");
+    }
+}

--- a/src/main/java/org/tndata/android/compass/task/GetUserActionsTask.java
+++ b/src/main/java/org/tndata/android/compass/task/GetUserActionsTask.java
@@ -104,6 +104,10 @@ public class GetUserActionsTask extends AsyncTask<String, Void, ArrayList<Action
 
     @Override
     protected void onPostExecute(ArrayList<Action> actions) {
+        Log.e("GetUserActionsTask", "Finished");
+        for(Action a : actions) {
+            Log.d("GetUserActionsTask", "- (" + a.getId() + ") " + a.getTitle());
+        }
         mCallback.actionsLoaded(actions);
     }
 

--- a/src/main/java/org/tndata/android/compass/task/GetUserBehaviorsTask.java
+++ b/src/main/java/org/tndata/android/compass/task/GetUserBehaviorsTask.java
@@ -1,6 +1,7 @@
 package org.tndata.android.compass.task;
 
 import android.os.AsyncTask;
+import android.util.Log;
 
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
@@ -96,6 +97,10 @@ public class GetUserBehaviorsTask extends AsyncTask<String, Void, ArrayList<Beha
 
     @Override
     protected void onPostExecute(ArrayList<Behavior> behaviors) {
+        Log.e("GetUserBehaviorTask", "Loaded behaviors");
+        for(Behavior b : behaviors) {
+            Log.d("GetUserActionsTask", "- (" + b.getId() + ") " + b.getTitle());
+        }
         mCallback.behaviorsLoaded(behaviors);
     }
 

--- a/src/main/java/org/tndata/android/compass/task/GetUserDataTask.java
+++ b/src/main/java/org/tndata/android/compass/task/GetUserDataTask.java
@@ -145,14 +145,28 @@ public class GetUserDataTask extends AsyncTask<String, Void, UserData> {
                 goals.add(goal);
 
                 // Set the Goal's parent categories
+                // parse these into Category objects and set on the Goal
+                ArrayList<Category> goalCategories = goal.getCategories();
                 JSONArray user_categories = goalJson.getJSONArray("user_categories");
                 Log.d(TAG, "Goal.user_categories JSON: " + user_categories.toString(2));
-                // TODO: parse these into Category objects and set on the Goal
+                for(int x = 0; x < user_categories.length(); x++) {
+                    JSONObject categoryJson = user_categories.getJSONObject(x);
+                    Category c = gson.fromJson(categoryJson.toString(), Category.class);
+                    goalCategories.add(c);
+                }
+                goal.setCategories(goalCategories);
 
                 // Set the Goal's child behaviors
+                // parse these into Behavior objects and set on the Goal
+                ArrayList<Behavior> goalBehaviors = goal.getBehaviors();
                 JSONArray user_behaviors = goalJson.getJSONArray("user_behaviors");
                 Log.d(TAG, "Goal.user_behaviors JSON: " + user_behaviors.toString(2));
-                // TODO parse these into Behavior objects and set on the Goal
+                for(int x = 0; x < user_behaviors.length(); x++) {
+                    JSONObject behaviorJson = user_behaviors.getJSONObject(x);
+                    Behavior b = gson.fromJson(behaviorJson.toString(), Behavior.class);
+                    goalBehaviors.add(b);
+                }
+                goal.setBehaviors(goalBehaviors);
 
                 Log.d(TAG, "Created UserGoal (" +
                         goal.getMappingId() + ") with Goal (" +
@@ -176,14 +190,28 @@ public class GetUserDataTask extends AsyncTask<String, Void, UserData> {
                 behaviors.add(behavior);
 
                 // Set the Behavior's parent goals
+                // parse these into Goal objects an set on the Behavior
+                ArrayList<Goal> behaviorGoals = behavior.getGoals();
                 JSONArray user_goals = behaviorJson.getJSONArray("user_goals");
                 Log.d(TAG, "Behavior.user_goals JSON: " + user_goals.toString(2));
-                // TODO: parse these into Goal objects an set on the Behavior
+                for (int x = 0; x < user_goals.length(); x++) {
+                    JSONObject goalJson = user_goals.getJSONObject(x);
+                    Goal g = gson.fromJson(goalJson.toString(), Goal.class);
+                    behaviorGoals.add(g);
+                }
+                behavior.setGoals(behaviorGoals);
 
                 // Set the Behavior's child Actions
+                // parse these into Action objects an set on the Behavior
+                ArrayList<Action> behaviorActions = behavior.getActions();
                 JSONArray user_actions = behaviorJson.getJSONArray("user_actions");
                 Log.d(TAG, "Behavior.user_actions JSON: " + user_actions.toString(2));
-                // TODO: parse these into Action objects an set on the Behavior
+                for (int x = 0; x < user_actions.length(); x++) {
+                    JSONObject actionJson = user_actions.getJSONObject(x);
+                    Action a = gson.fromJson(actionJson.toString(), Action.class);
+                    behaviorActions.add(a);
+                }
+                behavior.setActions(behaviorActions);
 
                 Log.d(TAG, "Created UserBehavior (" +
                         behavior.getMappingId() + ") with Behavior (" +
@@ -228,7 +256,7 @@ public class GetUserDataTask extends AsyncTask<String, Void, UserData> {
     @Override
     protected void onPostExecute(UserData userData) {
         Log.e(TAG, "Finished");
-        userData.logSelectedData("FROM UserDataTask.onPostExecute");
+        userData.logSelectedData("FROM UserDataTask.onPostExecute", false);
         mCallback.userDataLoaded(userData);
     }
 

--- a/src/main/java/org/tndata/android/compass/task/GetUserDataTask.java
+++ b/src/main/java/org/tndata/android/compass/task/GetUserDataTask.java
@@ -1,0 +1,201 @@
+package org.tndata.android.compass.task;
+
+import android.os.AsyncTask;
+import android.util.Log;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.tndata.android.compass.model.Action;
+import org.tndata.android.compass.model.Behavior;
+import org.tndata.android.compass.model.Category;
+import org.tndata.android.compass.model.Goal;
+import org.tndata.android.compass.model.Trigger;
+import org.tndata.android.compass.model.UserData;
+import org.tndata.android.compass.util.Constants;
+import org.tndata.android.compass.util.NetworkHelper;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A task that retrieves all of the user's selected data from the REST API, and returns
+ * a populated instance of UserData.
+ *
+ * See: https://app.tndata.org/api/users/
+ */
+public class GetUserDataTask extends AsyncTask<String, Void, UserData> {
+
+    private static final String TAG = "GetUserDataTask";
+    private GetUserDataListener mCallback;
+    private static Gson gson = new GsonBuilder().setFieldNamingPolicy(
+            FieldNamingPolicy.IDENTITY).create();
+
+    public interface GetUserDataListener {
+        public void userDataLoaded(UserData userData);
+    }
+
+    public GetUserDataTask(GetUserDataListener callback) {
+        mCallback = callback;
+    }
+
+    @Override
+    protected UserData doInBackground(String... params) {
+        String token = params[0];
+        String url = Constants.BASE_URL + "users/";
+        UserData userData = new UserData();
+        String result = ""; // result of http request
+
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put("Accept", "application/json");
+        headers.put("Content-type", "application/json");
+        headers.put("Authorization", "Token " + token);
+        InputStream stream = NetworkHelper.httpGetStream(url, headers);
+
+        if (stream == null) {
+            return null;
+        }
+
+        try {
+
+            BufferedReader bReader = new BufferedReader(new InputStreamReader(stream, "UTF-8"));
+            String line = null;
+            while ((line = bReader.readLine()) != null) {
+                result += line;
+            }
+            bReader.close();
+
+            JSONObject response = new JSONObject(result);
+            JSONArray jArray = response.getJSONArray("results");
+            JSONObject userJson = jArray.getJSONObject(0); // 1 user, so 1 result
+
+            // Parse the user-selected content, store in userData; wait till all data is set
+            // before syncing parent/child relationships.
+            userData.setCategories(parseCategories(userJson.getJSONArray("categories")), false);
+            userData.setGoals(parseGoals(userJson.getJSONArray("goals")), false);
+            userData.setBehaviors(parseBehaviors(userJson.getJSONArray("behaviors")), false);
+            userData.setActions(parseActions(userJson.getJSONArray("actions")), false);
+            userData.sync();
+
+            Log.e(TAG, "... finishing up GetUserDataTask.");
+            userData.logData();
+            
+            return userData;
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    protected ArrayList<Category> parseCategories(JSONArray categoryArray) {
+        ArrayList<Category> categories = new ArrayList<Category>();
+
+        try {
+            for (int i = 0; i < categoryArray.length(); i++) {
+                JSONObject categoryJson = categoryArray.getJSONObject(i);
+                Category category = gson.fromJson(categoryJson.getString("category"), Category.class);
+                category.setMappingId(categoryJson.getInt("id"));
+                categories.add(category);
+
+                Log.d(TAG, "Created UserCategory (" +
+                        category.getMappingId() + ") with Category (" +
+                        category.getId() + ")" + category.getTitle());
+
+            }
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        return categories;
+    }
+
+    protected ArrayList<Goal> parseGoals(JSONArray goalArray) {
+        ArrayList<Goal> goals = new ArrayList<Goal>();
+
+        try {
+            for (int i = 0; i < goalArray.length(); i++) {
+                JSONObject goalJson = goalArray.getJSONObject(i);
+                Goal goal = gson.fromJson(goalJson.getString("goal"), Goal.class);
+                goal.setMappingId(goalJson.getInt("id"));
+                goals.add(goal);
+
+                Log.d(TAG, "Created UserGoal (" +
+                        goal.getMappingId() + ") with Goal (" +
+                        goal.getId() + ")" + goal.getTitle());
+
+            }
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        return goals;
+    }
+
+    protected ArrayList<Behavior> parseBehaviors(JSONArray behaviorArray) {
+        ArrayList<Behavior> behaviors = new ArrayList<Behavior>();
+
+        try {
+            for (int i = 0; i < behaviorArray.length(); i++) {
+                JSONObject behaviorJson = behaviorArray.getJSONObject(i);
+                Behavior behavior = gson.fromJson(behaviorJson.getString("behavior"), Behavior.class);
+                behavior.setMappingId(behaviorJson.getInt("id"));
+                behaviors.add(behavior);
+
+                Log.d(TAG, "Created UserBehavior (" +
+                        behavior.getMappingId() + ") with Behavior (" +
+                        behavior.getId() + ")" + behavior.getTitle());
+
+            }
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        return behaviors;
+    }
+
+    protected ArrayList<Action> parseActions(JSONArray actionArray) {
+        ArrayList<Action> actions = new ArrayList<Action>();
+
+        try {
+            for (int i = 0; i < actionArray.length(); i++) {
+                JSONObject actionJson = actionArray.getJSONObject(i);
+                Action action = gson.fromJson(actionJson.getString("action"), Action.class);
+                action.setMappingId(actionJson.getInt("id"));
+                actions.add(action);
+
+                Log.d(TAG, "Created UserAction (" +
+                        action.getMappingId() + ") with Action (" +
+                        action.getId() + ")" + action.getTitle());
+
+                Log.d(TAG, "Custom Trigger: " + actionJson.getString("custom_trigger"));
+
+                if (!actionJson.isNull("custom_trigger")) {
+                    action.setCustomTrigger(
+                            gson.fromJson(actionJson.getString("custom_trigger"), Trigger.class));
+
+                    Log.d(TAG, "loaded trigger: " + action.getTrigger().getName());
+                }
+            }
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        return actions;
+    }
+
+    @Override
+    protected void onPostExecute(UserData userData) {
+        Log.e(TAG, "Finished");
+        userData.logSelectedData("FROM UserDataTask.onPostExecute");
+        mCallback.userDataLoaded(userData);
+    }
+
+}


### PR DESCRIPTION
This PR contains work that 

* extracts the user-selected `Category`, `Goal`, `Behavior`, and `Action` objects from the `CompassApplication` into a container `UserData` class--a single instance of which is stored in the `CompassApplication` instead.
* `UserData` should do a better job of keeping the hierarchy of content up-to-date when something is added or removed.
* Adds a `GetUserDataTask` which pulls all of the user-selected data from the `/api/users/` endpoint in one request
* Simplifies the `MainActivity` by removing a bunch of unnecessary callbacks, and...
* Simplifies the `CategoryFragment` and `MyGoalsFragment` classes by removing unnecessary listeners.