### PR TITLE
Fix crashing Behavior progress activity

### DIFF
--- a/src/main/java/org/tndata/android/compass/task/GetUserBehaviorsTask.java
+++ b/src/main/java/org/tndata/android/compass/task/GetUserBehaviorsTask.java
@@ -97,9 +97,12 @@ public class GetUserBehaviorsTask extends AsyncTask<String, Void, ArrayList<Beha
 
     @Override
     protected void onPostExecute(ArrayList<Behavior> behaviors) {
-        Log.e("GetUserBehaviorTask", "Loaded behaviors");
-        for(Behavior b : behaviors) {
-            Log.d("GetUserActionsTask", "- (" + b.getId() + ") " + b.getTitle());
+        if(behaviors != null) {
+            for (Behavior b : behaviors) {
+                Log.d("GetUserBehaviorsTask", "- (" + b.getId() + ") " + b.getTitle());
+            }
+        } else {
+            Log.d("GetUserBehaviorTask", "^^^^^^^ behaviors is null");
         }
         mCallback.behaviorsLoaded(behaviors);
     }


### PR DESCRIPTION
This PR should fix an issue that causes the `BehaviorProgressActivity` to crash when launched from a notification. It ensures that:

* fetching User data includes an auth token in the request
* we exit cleanly if the returned data is null
