### PR TITLE
Make DatePicker hide when it is not required

### DIFF
--- a/src/main/res/layout/view_survey_openended.xml
+++ b/src/main/res/layout/view_survey_openended.xml
@@ -55,7 +55,7 @@
             android:layout_gravity="center_horizontal"
             android:datePickerMode="spinner"
             android:calendarViewShown="false"
-            android:visibility="visible"/>
+            android:visibility="gone"/>
     </LinearLayout>
 
     <include


### PR DESCRIPTION
After the dob selection question, the DatePicker doesn't show up any more.