### PR TITLE
Add an option bundle to the loader, fix square view atop the goal picker

### DIFF
--- a/src/main/java/org/tndata/android/compass/activity/ActionActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/ActionActivity.java
@@ -178,7 +178,7 @@ public class ActionActivity
             mAction = actions.get(0);
 
             //Populate UI
-            ImageLoader.loadBitmap(mActionImage, mAction.getIconUrl(), false);
+            ImageLoader.loadBitmap(mActionImage, mAction.getIconUrl(), new ImageLoader.Options());
             mActionTitle.setText(mAction.getTitle());
             if (!mAction.getHTMLDescription().isEmpty()){
                 mActionDescription.setText(Html.fromHtml(mAction.getHTMLDescription(), null, new CompassTagHandler(this)));

--- a/src/main/java/org/tndata/android/compass/activity/ChooseActionsActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/ChooseActionsActivity.java
@@ -214,7 +214,7 @@ public class ChooseActionsActivity extends AppCompatActivity implements
 
                     if (action.getIconUrl() != null && !action.getIconUrl().isEmpty()) {
                         ImageLoader.loadBitmap(((ActionViewHolder) viewHolder).iconImageView,
-                                action.getIconUrl(), false);
+                                action.getIconUrl(), new ImageLoader.Options());
                     }
 
                     if (action_is_selected) {

--- a/src/main/java/org/tndata/android/compass/activity/GoalTryActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/GoalTryActivity.java
@@ -189,7 +189,7 @@ public class GoalTryActivity extends AppCompatActivity implements
                     if (behavior.getIconUrl() != null
                             && !behavior.getIconUrl().isEmpty()) {
                         ImageLoader.loadBitmap(((TryGoalViewHolder) viewHolder).iconImageView,
-                                behavior.getIconUrl(), false);
+                                behavior.getIconUrl(), new ImageLoader.Options());
                     }
 
                     if (behavior_is_selected) {

--- a/src/main/java/org/tndata/android/compass/activity/MainActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/MainActivity.java
@@ -145,7 +145,7 @@ public class MainActivity extends AppCompatActivity implements
                     mHeaderImageView.invalidate();
                     //Log.d("MEASURE", mHeroView.getMeasuredWidth()+"");
                     //Log.d("MEASURE", mHeroView.getMeasuredHeight()+"");
-                    ImageLoader.loadBitmap(mHeaderImageView, url, false, false);
+                    ImageLoader.loadBitmap(mHeaderImageView, url, new ImageLoader.Options().setUsePlaceholder(false));
                 } else {
                     //TODO there is a bug here, when the user scrolls fast, the resource gets
                     //TODO  loaded before the cached image. When that happens, some other

--- a/src/main/java/org/tndata/android/compass/adapter/ChooseGoalsAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/ChooseGoalsAdapter.java
@@ -1,9 +1,7 @@
 package org.tndata.android.compass.adapter;
 
 import android.content.Context;
-import android.graphics.Bitmap;
 import android.graphics.Color;
-import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.GradientDrawable;
 import android.os.Build;
 import android.support.annotation.NonNull;
@@ -25,7 +23,6 @@ import org.tndata.android.compass.ui.button.TransitionButton;
 import org.tndata.android.compass.ui.parallaxrecyclerview.HeaderLayoutManagerFixed;
 import org.tndata.android.compass.ui.parallaxrecyclerview.ParallaxRecyclerAdapter;
 import org.tndata.android.compass.util.CompassTagHandler;
-import org.tndata.android.compass.util.ImageHelper;
 import org.tndata.android.compass.util.ImageLoader;
 
 import java.util.ArrayList;
@@ -108,11 +105,6 @@ public class ChooseGoalsAdapter
 
         ImageView headerImageView = (ImageView)header.findViewById(R.id.choose_goals_header_imageview);
         mCategory.loadImageIntoView(mContext, headerImageView);
-        Bitmap bmp = ((BitmapDrawable)headerImageView.getDrawable()).getBitmap();
-        if (bmp != null){
-            int size = (int)mContext.getResources().getDimension(R.dimen.header_category_icon_image_size);
-            headerImageView.setImageBitmap(ImageHelper.getCircleBitmap(bmp, size));
-        }
 
         ((HeaderLayoutManagerFixed)mRecyclerView.getLayoutManager()).setHeaderIncrementFixer(header);
         setShouldClipView(false);
@@ -284,7 +276,7 @@ public class ChooseGoalsAdapter
                 }
 
                 if (goal.getIconUrl() != null && !goal.getIconUrl().isEmpty()){
-                    ImageLoader.loadBitmap(holder.icon, goal.getIconUrl(), false);
+                    ImageLoader.loadBitmap(holder.icon, goal.getIconUrl(), new ImageLoader.Options());
                 }
 
                 switch (goalStates[position-1]){

--- a/src/main/java/org/tndata/android/compass/adapter/MyPrioritiesGoalAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/MyPrioritiesGoalAdapter.java
@@ -122,7 +122,7 @@ public class MyPrioritiesGoalAdapter extends RecyclerView.Adapter<MyPrioritiesGo
             behaviorView.setLeftPadding(20);
             behaviorView.getTextView().setText(behavior.getTitle());
             if (behavior.getIconUrl() != null){
-                ImageLoader.loadBitmap(behaviorView.getImageView(), behavior.getIconUrl(), false);
+                ImageLoader.loadBitmap(behaviorView.getImageView(), behavior.getIconUrl(), new ImageLoader.Options());
             }
             behaviorView.setOnClickListener(holder);
 
@@ -137,7 +137,7 @@ public class MyPrioritiesGoalAdapter extends RecyclerView.Adapter<MyPrioritiesGo
                 actionView.setLeftPadding(30);
                 actionView.getTextView().setText(action.getTitle());
                 if (action.getIconUrl() != null){
-                    ImageLoader.loadBitmap(actionView.getImageView(), action.getIconUrl(), false);
+                    ImageLoader.loadBitmap(actionView.getImageView(), action.getIconUrl(), new ImageLoader.Options());
                 }
                 actionView.setOnClickListener(holder);
                 holder.offspring.addView(actionView);

--- a/src/main/java/org/tndata/android/compass/fragment/BehaviorFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/BehaviorFragment.java
@@ -103,7 +103,7 @@ public class BehaviorFragment extends Fragment implements ActionLoaderListener, 
         });
         if (mBehavior.getIconUrl() != null && !mBehavior.getIconUrl().isEmpty()) {
             ImageView iconImageView = (ImageView) v.findViewById(R.id.behavior_icon_imageview);
-            ImageLoader.loadBitmap(iconImageView, mBehavior.getIconUrl(), false);
+            ImageLoader.loadBitmap(iconImageView, mBehavior.getIconUrl(), new ImageLoader.Options());
 
         }
         mProgressBar = (ProgressBar) v.findViewById(R.id.behavior_progressbar);

--- a/src/main/java/org/tndata/android/compass/model/Behavior.java
+++ b/src/main/java/org/tndata/android/compass/model/Behavior.java
@@ -185,7 +185,7 @@ public class Behavior extends TDCBase implements Serializable,
     public void loadIconIntoView(Context context, ImageView imageView) {
         String iconUrl = getIconUrl();
         if(iconUrl != null && !iconUrl.isEmpty()) {
-            ImageLoader.loadBitmap(imageView, iconUrl, false);
+            ImageLoader.loadBitmap(imageView, iconUrl, new ImageLoader.Options());
         }
     }
 

--- a/src/main/java/org/tndata/android/compass/model/Category.java
+++ b/src/main/java/org/tndata/android/compass/model/Category.java
@@ -190,14 +190,14 @@ public class Category extends TDCBase implements Serializable,
     public void loadIconIntoView(Context context, ImageView imageView) {
         String iconUrl = getIconUrl();
         if(iconUrl != null && !iconUrl.isEmpty()){
-            ImageLoader.loadBitmap(imageView, iconUrl, false);
+            ImageLoader.loadBitmap(imageView, iconUrl, new ImageLoader.Options());
         }
     }
 
     public void loadImageIntoView(Context context, ImageView imageView) {
         String url = getImageUrl();
         if(url != null && !url.isEmpty()){
-            ImageLoader.loadBitmap(imageView, url, false);
+            ImageLoader.loadBitmap(imageView, url, new ImageLoader.Options().setUsePlaceholder(false).setCropToCircle(true));
         }
     }
 }

--- a/src/main/java/org/tndata/android/compass/model/Goal.java
+++ b/src/main/java/org/tndata/android/compass/model/Goal.java
@@ -183,7 +183,7 @@ public class Goal extends TDCBase implements Serializable, Comparable<Goal> {
     public void loadIconIntoView(Context context, ImageView imageView) {
         String iconUrl = getIconUrl();
         if(iconUrl != null && !iconUrl.isEmpty()) {
-            ImageLoader.loadBitmap(imageView, iconUrl, false);
+            ImageLoader.loadBitmap(imageView, iconUrl, new ImageLoader.Options());
         }
         /*
         // TODO: only show goal icons (above) until we figure out what to do here.

--- a/src/main/java/org/tndata/android/compass/ui/ActionListView.java
+++ b/src/main/java/org/tndata/android/compass/ui/ActionListView.java
@@ -58,7 +58,7 @@ public class ActionListView extends LinearLayout {
             if (mAction.getIconUrl() != null
                     && !mAction.getIconUrl().isEmpty()) {
                 mImageLoader.loadBitmap(mIconImageView,
-                        mAction.getIconUrl(), false);
+                        mAction.getIconUrl(), new ImageLoader.Options());
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/org/tndata/android/compass/ui/BehaviorListView.java
+++ b/src/main/java/org/tndata/android/compass/ui/BehaviorListView.java
@@ -73,7 +73,7 @@ public class BehaviorListView extends LinearLayout {
         try {
             mTitleTextView.setText(mBehavior.getTitle());
             if (mBehavior.getIconUrl() != null && !mBehavior.getIconUrl().isEmpty()){
-                ImageLoader.loadBitmap(mIconImageView, mBehavior.getIconUrl(), false);
+                ImageLoader.loadBitmap(mIconImageView, mBehavior.getIconUrl(), new ImageLoader.Options());
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/org/tndata/android/compass/util/ImageHelper.java
+++ b/src/main/java/org/tndata/android/compass/util/ImageHelper.java
@@ -1,6 +1,5 @@
 package org.tndata.android.compass.util;
 
-import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -17,6 +16,7 @@ import android.os.Build;
 import android.widget.ImageView;
 
 import org.tndata.android.compass.R;
+
 
 public class ImageHelper {
     public final static int SELECTED = 1;
@@ -93,7 +93,7 @@ public class ImageHelper {
         paint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.SRC_IN));
         canvas.drawBitmap(thumbnail, rect, rect, paint);
 
-        thumbnail.recycle();
+        //thumbnail.recycle();
         return output;
     }
 }

--- a/src/main/java/org/tndata/android/compass/util/ImageLoader.java
+++ b/src/main/java/org/tndata/android/compass/util/ImageLoader.java
@@ -642,7 +642,7 @@ public final class ImageLoader{
             //  to be written to cache. If the task was cancelled, the Bitmap might be corrupt.
             if (!wasCancelled && request.mResult != null){
                 MemoryCache.instance().addBitmapToMemoryCache(request.mUrl, request.mResult);
-                completeLodRequest(request);
+                completeLoadRequest(request);
                 queueWriteRequest(new WriteRequest(request.mResult, request.mUrl));
             }
             //The request is closed
@@ -665,7 +665,7 @@ public final class ImageLoader{
         }
     }
 
-    private static void completeLodRequest(LoadRequest request){
+    private static void completeLoadRequest(LoadRequest request){
         Bitmap result = request.mResult;
         if (result != null){
             if (request.mOptions.mCropToCircle){


### PR DESCRIPTION
Now, calls to loadBitmap need to provide an option bundle with the parameters of the load.