### PR TITLE
Exclude the categories that are selected by default during onboarding

### DIFF
--- a/src/main/java/org/tndata/android/compass/activity/LoginActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/LoginActivity.java
@@ -326,7 +326,7 @@ public class LoginActivity
     @Override
     public void onParseSuccess(int requestCode, ParserModels.ResultSet result){
         if (result instanceof User){
-            mGetCategoriesRC = HttpRequest.get(this, API.getCategoriesUrl());
+            mGetCategoriesRC = HttpRequest.get(this, API.getCategoriesUrl() + "&selected_by_default=0");
             mGetPlacesRC = HttpRequest.get(this, API.getUserPlacesUrl());
         }
         else if (result instanceof ParserModels.CategoryContentResultSet){


### PR DESCRIPTION
PR is for discussion. Soon we'll have Categories that are selected by default, and we probably don't want to display these during on-boarding (particularly because it could mess up the category chooser's layout).  

This is a simple, inelegant fix, but I'm not sure if this well mess up anything elsewhere in the app.

