### PR TITLE
Change some text from 1st to 2nd person & exclude auto-selected categories for both new and exising users.

### DIFF
--- a/src/main/java/org/tndata/android/compass/CompassApplication.java
+++ b/src/main/java/org/tndata/android/compass/CompassApplication.java
@@ -142,6 +142,23 @@ public class CompassApplication extends Application{
     }
 
     /**
+     * A filtered list of public categories. At the moment, this method
+     * excludes those categories that are selected for all users by default.
+     *
+     * @return the unordered list of public categories, excluding those selected by default.
+     */
+    public List<CategoryContent> getFilteredCategoryList() {
+        ArrayList filtered_categories = new ArrayList<>();
+        for(CategoryContent category: mPublicCategories.values()) {
+            if(!category.isSelectedByDefault()) {
+                filtered_categories.add(category);
+            }
+        }
+        return filtered_categories;
+    }
+
+
+    /**
      * Feed data setter.
      *
      * @param feedData the user's feed data bundle.

--- a/src/main/java/org/tndata/android/compass/activity/LoginActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/LoginActivity.java
@@ -261,9 +261,19 @@ public class LoginActivity
         setUser(user);
     }
 
+    /**
+     * Fetches public categories, but excludes those that are pre-selected for the user
+     * by default. This method is only applicable to on-boarding, hence the method
+     * definition here.
+     *
+     */
+    private String getCategoriesUrl() {
+        return API.getCategoriesUrl() + "&selected_by_default=0";
+    }
+
     private void setUser(User user){
         mApplication.setUser(user, true);
-        mGetCategoriesRC = HttpRequest.get(this, API.getCategoriesUrl());
+        mGetCategoriesRC = HttpRequest.get(this, this.getCategoriesUrl());
     }
 
     @Override
@@ -326,7 +336,7 @@ public class LoginActivity
     @Override
     public void onParseSuccess(int requestCode, ParserModels.ResultSet result){
         if (result instanceof User){
-            mGetCategoriesRC = HttpRequest.get(this, API.getCategoriesUrl() + "&selected_by_default=0");
+            mGetCategoriesRC = HttpRequest.get(this, this.getCategoriesUrl());
             mGetPlacesRC = HttpRequest.get(this, API.getUserPlacesUrl());
         }
         else if (result instanceof ParserModels.CategoryContentResultSet){

--- a/src/main/java/org/tndata/android/compass/activity/LoginActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/LoginActivity.java
@@ -261,19 +261,9 @@ public class LoginActivity
         setUser(user);
     }
 
-    /**
-     * Fetches public categories, but excludes those that are pre-selected for the user
-     * by default. This method is only applicable to on-boarding, hence the method
-     * definition here.
-     *
-     */
-    private String getCategoriesUrl() {
-        return API.getCategoriesUrl() + "&selected_by_default=0";
-    }
-
     private void setUser(User user){
         mApplication.setUser(user, true);
-        mGetCategoriesRC = HttpRequest.get(this, this.getCategoriesUrl());
+        mGetCategoriesRC = HttpRequest.get(this, API.getCategoriesUrl());
     }
 
     @Override
@@ -336,7 +326,7 @@ public class LoginActivity
     @Override
     public void onParseSuccess(int requestCode, ParserModels.ResultSet result){
         if (result instanceof User){
-            mGetCategoriesRC = HttpRequest.get(this, this.getCategoriesUrl());
+            mGetCategoriesRC = HttpRequest.get(this, API.getCategoriesUrl());
             mGetPlacesRC = HttpRequest.get(this, API.getUserPlacesUrl());
         }
         else if (result instanceof ParserModels.CategoryContentResultSet){

--- a/src/main/java/org/tndata/android/compass/fragment/CheckInFeedbackFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/CheckInFeedbackFragment.java
@@ -114,8 +114,7 @@ public class CheckInFeedbackFragment extends Fragment implements SeekBar.OnSeekB
         }*/
 
         //Header title
-        String title = mUserGoal.getTitle().substring(0, 1).toLowerCase() + mUserGoal.getTitle().substring(1);
-        goalTitle.setText(getResources().getString(R.string.check_in_feedback_goal, title));
+        goalTitle.setText(getResources().getString(R.string.check_in_feedback_goal, mUserGoal.getTitle()));
 
         mBar.setOnSeekBarChangeListener(this);
     }

--- a/src/main/java/org/tndata/android/compass/fragment/ChooseInterestsFragment.java
+++ b/src/main/java/org/tndata/android/compass/fragment/ChooseInterestsFragment.java
@@ -159,7 +159,7 @@ public class ChooseInterestsFragment
         if (result instanceof ParserModels.UserCategoryResultSet){
             List<UserCategory> categories = ((ParserModels.UserCategoryResultSet)result).results;
             if (categories != null){
-                mAdapter.setCategories(mApplication.getPublicCategoryList(), categories);
+                mAdapter.setCategories(mApplication.getFilteredCategoryList(), categories);
             }
         }
     }

--- a/src/main/java/org/tndata/android/compass/model/CategoryContent.java
+++ b/src/main/java/org/tndata/android/compass/model/CategoryContent.java
@@ -33,6 +33,9 @@ public class CategoryContent extends TDCContent implements Serializable{
     @SerializedName("packaged_content")
     private boolean mPackagedContent = false;
 
+    @SerializedName("selected_by_default")
+    private boolean mSelectedByDefault = false;
+
 
     /*---------*
      * GETTERS *
@@ -57,6 +60,8 @@ public class CategoryContent extends TDCContent implements Serializable{
     public boolean isPackagedContent(){
         return mPackagedContent;
     }
+
+    public boolean isSelectedByDefault() { return mSelectedByDefault; }
 
     @Override
     protected String getType(){

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -81,7 +81,7 @@
     <!-- Library -->
     <string name="library_goals_content_header">Compass can help me&#8230;</string>
     <string name="library_behaviors_content_header">You can do it!</string>
-    <string name="library_behavior_title">I want to %1$s</string>
+    <string name="library_behavior_title">%1$s</string>
     <string name="library_behavior_yes">Yes, I\'m in</string>
     <string name="library_detail_header">Here\'s why</string>
     <string name="library_detail_more_info">More info</string>
@@ -236,8 +236,8 @@
     <string name="card_footer_see_more">SEE MORE</string>
 
     <!-- Check in -->
-    <string name="check_in_feedback_title">How am I doing?</string>
-    <string name="check_in_feedback_goal">I want to %1$s.</string>
+    <string name="check_in_feedback_title">How are you doing?</string>
+    <string name="check_in_feedback_goal">%1$s.</string>
     <string name="check_in_feedback_poor">Poor</string>
     <string name="check_in_feedback_fair">Fair</string>
     <string name="check_in_feedback_good">Good</string>


### PR DESCRIPTION
To exclude the auto-selected categories, I:

1. Added the `selected_by_default` attribute on the `CategoryContent` model,
2. Added a `getFilteredCategoryList` in the application; it returns public categories, excluding those where `selected_by_default` is `true`.
3. Finally, I called the `getFitleredCategoryList` instead of the `getPublicCategoryList` method in the fragment that displays those categories.