### PR TITLE
Self-Enroll Categories

### DIFF
--- a/src/main/java/org/tndata/android/compass/activity/ChooseCategoryActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/ChooseCategoryActivity.java
@@ -42,7 +42,7 @@ public class ChooseCategoryActivity
 
         RecyclerView recyclerView = (RecyclerView)findViewById(R.id.choose_category_list);
         recyclerView.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false));
-        recyclerView.setAdapter(new ChooseCategoryAdapter(this, this, app.getPublicCategoryList()));
+        recyclerView.setAdapter(new ChooseCategoryAdapter(this, this, app.getFilteredCategoryList()));
     }
 
     @Override

--- a/src/main/java/org/tndata/android/compass/util/CompassUtil.java
+++ b/src/main/java/org/tndata/android/compass/util/CompassUtil.java
@@ -211,7 +211,8 @@ public final class CompassUtil{
             return R.drawable.tile_romance;
         }
         else{
-            return 0;
+            // Default to our main hero image.
+            return R.drawable.compass_master_illustration;
         }
     }
 


### PR DESCRIPTION
**WIP: Do not merge**

This branch implements a few minor changes to the android app in support of a possible new approach for allowing users to self-enroll in certain categories.

1. Bug fix: If we don't have a hero image for a category, fall back to the master illustration.
2. Use the filtered list of categories in `ChooseCategoryActivity`, so that users will see the public, but slightly different categories that are marked as `enrolled_when_selected` (i.e. users get enrolled in all child content when they select the category).