### PR TITLE
Include a device_type paramter

### DIFF
--- a/src/main/java/org/tndata/android/compass/util/API.java
+++ b/src/main/java/org/tndata/android/compass/util/API.java
@@ -105,6 +105,7 @@ public final class API{
         JSONObject postDeviceRegistrationBody = new JSONObject();
         try{
             postDeviceRegistrationBody.put("registration_id", registrationId)
+                    .put("device_type", "android")
                     .put("device_name", Build.MANUFACTURER + " " + Build.PRODUCT);
         }
         catch (JSONException jsonx){


### PR DESCRIPTION
… when sending the GCM registration id back to our api.