### PR TITLE
Check that a Category's image url is not an empty string.

### DIFF
--- a/src/main/java/org/tndata/android/compass/activity/ActionActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/ActionActivity.java
@@ -111,7 +111,7 @@ public class ActionActivity
     private void setHeader(){
         View header = inflateHeader(R.layout.header_hero);
         ImageView image = (ImageView)header.findViewById(R.id.header_hero_image);
-        if (mUserCategory == null){
+        if (mUserCategory == null || mUserCategory.getCategory().getImageUrl().isEmpty()){
             image.setImageResource(R.drawable.compass_master_illustration);
         }
         else{


### PR DESCRIPTION
This change fixes the issues where the header image being displayed is a default `ic_compass` icon instead of the `compass_master_illustration.jpg` image.