### PR TITLE
Add to Calendar option on ActionActivity & update external resource usage

### DIFF
--- a/src/main/java/org/tndata/android/compass/activity/ActionActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/ActionActivity.java
@@ -30,6 +30,12 @@ import org.tndata.android.compass.util.API;
 import org.tndata.android.compass.util.ImageLoader;
 import org.tndata.android.compass.util.NotificationUtil;
 
+import java.text.ParsePosition;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+
 import es.sandwatch.httprequests.HttpRequest;
 import es.sandwatch.httprequests.HttpRequestError;
 
@@ -430,6 +436,62 @@ public class ActionActivity
             removeButton.setOnClickListener(buttonHandler);
             cancelButton.setOnClickListener(buttonHandler);
             dialog.show();
+        }
+    }
+
+    /**
+     * Detect if the action belongs to a user and has a "datetime" external resource.
+     * See also: sendToCalendar.
+     *
+     * @return boolean
+     */
+    private boolean hasDatetimeExternalResource() {
+        if(isUserAction()) {
+            UserAction userAction = (UserAction) mAction;
+            String externalResource = userAction.getExternalResource();
+            String externalResourceName = userAction.getExternalResourceName();
+
+            // ensure the resource name == "datetime" and the resource value exists.
+            return externalResourceName.equals("datetime") && !externalResource.isEmpty();
+        }
+        return false;
+    }
+
+    /**
+     * If the user is viewing a UserAction whose externalResourceName is "datetime", then the
+     * externalResource is a datetime string (of the form YYYY-mm-dd hh:mm:ss). This is likely
+     * for a specific scheduled event, so we'll give them an option to add to their Calendar.
+     *
+     */
+    public void sendToCalendar() {
+        if(isUserAction() && hasDatetimeExternalResource()) {
+            UserAction userAction = (UserAction) mAction;
+            String externalResource = userAction.getExternalResource();
+
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd kk:mm:ss", Locale.getDefault());
+            ParsePosition pos = new ParsePosition(0);
+            Date startDate = (Date) sdf.parseObject(externalResource, pos);
+
+            // Convert the parsed date into milliseconds and generate a duration,
+            // (a default of 2 hours should be good) then ask to save to the calendar.
+            Calendar cal = Calendar.getInstance();
+            cal.setTime(startDate);
+
+            // Generate a start/end duration for the calendar's event.
+            // We'll just make all events a 2-hour duration.
+            long start = cal.getTimeInMillis();
+            cal.add(Calendar.HOUR_OF_DAY, 2);
+            long end = cal.getTimeInMillis();
+
+
+            // launch an intent for the calendar
+            Intent intent = new Intent(Intent.ACTION_EDIT);
+            intent.setType("vnd.android.cursor.item/event");
+            intent.putExtra("title", userAction.getTitle());
+            intent.putExtra("description", userAction.getDescription());
+            intent.putExtra("beginTime", start);
+            intent.putExtra("endTime", end);
+            startActivity(intent);
         }
     }
 

--- a/src/main/java/org/tndata/android/compass/activity/ActionActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/ActionActivity.java
@@ -440,58 +440,42 @@ public class ActionActivity
     }
 
     /**
-     * Detect if the action belongs to a user and has a "datetime" external resource.
-     * See also: sendToCalendar.
-     *
-     * @return boolean
-     */
-    private boolean hasDatetimeExternalResource() {
-        if(isUserAction()) {
-            UserAction userAction = (UserAction) mAction;
-            String externalResource = userAction.getExternalResource();
-            String externalResourceName = userAction.getExternalResourceName();
-
-            // ensure the resource name == "datetime" and the resource value exists.
-            return externalResourceName.equals("datetime") && !externalResource.isEmpty();
-        }
-        return false;
-    }
-
-    /**
      * If the user is viewing a UserAction whose externalResourceName is "datetime", then the
      * externalResource is a datetime string (of the form YYYY-mm-dd hh:mm:ss). This is likely
      * for a specific scheduled event, so we'll give them an option to add to their Calendar.
      *
      */
     public void sendToCalendar() {
-        if(isUserAction() && hasDatetimeExternalResource()) {
+        if(isUserAction()) {
             UserAction userAction = (UserAction) mAction;
-            String externalResource = userAction.getExternalResource();
+            if(userAction.getAction().hasDatetimeResource()) {
+                String externalResource = userAction.getExternalResource();
 
-            SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd kk:mm:ss", Locale.getDefault());
-            ParsePosition pos = new ParsePosition(0);
-            Date startDate = (Date) sdf.parseObject(externalResource, pos);
+                SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd kk:mm:ss", Locale.getDefault());
+                ParsePosition pos = new ParsePosition(0);
+                Date startDate = (Date) sdf.parseObject(externalResource, pos);
 
-            // Convert the parsed date into milliseconds and generate a duration,
-            // (a default of 2 hours should be good) then ask to save to the calendar.
-            Calendar cal = Calendar.getInstance();
-            cal.setTime(startDate);
+                // Convert the parsed date into milliseconds and generate a duration,
+                // (a default of 2 hours should be good) then ask to save to the calendar.
+                Calendar cal = Calendar.getInstance();
+                cal.setTime(startDate);
 
-            // Generate a start/end duration for the calendar's event.
-            // We'll just make all events a 2-hour duration.
-            long start = cal.getTimeInMillis();
-            cal.add(Calendar.HOUR_OF_DAY, 2);
-            long end = cal.getTimeInMillis();
+                // Generate a start/end duration for the calendar's event.
+                // We'll just make all events a 2-hour duration.
+                long start = cal.getTimeInMillis();
+                cal.add(Calendar.HOUR_OF_DAY, 2);
+                long end = cal.getTimeInMillis();
 
 
-            // launch an intent for the calendar
-            Intent intent = new Intent(Intent.ACTION_EDIT);
-            intent.setType("vnd.android.cursor.item/event");
-            intent.putExtra("title", userAction.getTitle());
-            intent.putExtra("description", userAction.getDescription());
-            intent.putExtra("beginTime", start);
-            intent.putExtra("endTime", end);
-            startActivity(intent);
+                // launch an intent for the calendar
+                Intent intent = new Intent(Intent.ACTION_EDIT);
+                intent.setType("vnd.android.cursor.item/event");
+                intent.putExtra("title", userAction.getTitle());
+                intent.putExtra("description", userAction.getDescription());
+                intent.putExtra("beginTime", start);
+                intent.putExtra("endTime", end);
+                startActivity(intent);
+            }
         }
     }
 

--- a/src/main/java/org/tndata/android/compass/activity/ActionActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/ActionActivity.java
@@ -449,6 +449,12 @@ public class ActionActivity
         if(isUserAction()) {
             UserAction userAction = (UserAction) mAction;
             if(userAction.getAction().hasDatetimeResource()) {
+
+                // NOTE: Let's save this as a positive action, prior to adding to their calendar.
+                startService(new Intent(this, ActionReportService.class)
+                        .putExtra(ActionReportService.ACTION_KEY, mAction)
+                        .putExtra(ActionReportService.STATE_KEY, ActionReportService.STATE_COMPLETED));
+
                 String externalResource = userAction.getExternalResource();
 
                 SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd kk:mm:ss", Locale.getDefault());
@@ -465,7 +471,6 @@ public class ActionActivity
                 long start = cal.getTimeInMillis();
                 cal.add(Calendar.HOUR_OF_DAY, 2);
                 long end = cal.getTimeInMillis();
-
 
                 // launch an intent for the calendar
                 Intent intent = new Intent(Intent.ACTION_EDIT);

--- a/src/main/java/org/tndata/android/compass/activity/PlaygroundActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/PlaygroundActivity.java
@@ -1,12 +1,21 @@
 package org.tndata.android.compass.activity;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.view.View;
 
 import org.tndata.android.compass.R;
 import org.tndata.android.compass.service.LocationNotificationService;
 import org.tndata.android.compass.ui.TransitionButton;
+
+import java.text.ParsePosition;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import at.grabner.circleprogress.CircleProgressView;
 
@@ -19,7 +28,7 @@ public class PlaygroundActivity extends AppCompatActivity implements View.OnClic
 
     private TransitionButton button;
     private int state;
-
+    static String TAG = "Playground";
 
     @Override
     protected void onCreate(Bundle savedInstanceState){
@@ -39,6 +48,8 @@ public class PlaygroundActivity extends AppCompatActivity implements View.OnClic
 
         findViewById(R.id.playground_button_start).setOnClickListener(this);
         findViewById(R.id.playground_button_kill).setOnClickListener(this);
+
+        findViewById(R.id.playground_button_calendar).setOnClickListener(this);
     }
 
     @Override
@@ -66,6 +77,73 @@ public class PlaygroundActivity extends AppCompatActivity implements View.OnClic
 
             case R.id.playground_button_kill:
                 LocationNotificationService.kill(this);
+                break;
+
+            case R.id.playground_button_calendar:
+
+                // --------------------------------------------------------------------
+                // This is an experiment in trying to detect & parse a date from a string.
+                // 1. Use a regex to see if we have a date in some chunk of text.
+                // 2. If so, pull it out and create a date object, setting the approprate year
+                // 3. Use the created date to construct a duration and launch an Intent to
+                //    save that in the user's calendar.
+                // --------------------------------------------------------------------
+                String description = "Ages 5-12: Registration Required.\n" +
+                        "\nPersonal Safety - Wednesday, July 13, 2:30 pm-3:30 pm. Children ages 6-12.";
+                //Pattern p = Pattern.compile("[A-Z][a-z]+ \\d+, *\\d+:\\d\\d *[am|pm]* *- *\\d+:\\d\\d *[am|pm]*");
+                Pattern p = Pattern.compile("[A-Z][a-z]+ \\d+, *\\d+:\\d\\d *[am|pm]*"); // only the start date/time
+                Matcher m = p.matcher(description);
+
+                Date date;
+
+                if (m.find()) {
+                    // match
+                    String startString = description.substring(m.start(), m.end());
+
+                    Log.d(TAG, "FOUND! '" + m.group() + "' (from " + m.start() + " to " + m.end() + ")");
+                    Log.d(TAG, "---> '" + description.substring(m.start(), m.end()) + "'");
+
+                    SimpleDateFormat sdf = new SimpleDateFormat("MMMM dd, hh:mm aa");
+                    ParsePosition pos = new ParsePosition(0);
+                    Date startDate = (Date)sdf.parseObject(startString, pos);
+
+                    // --------------------------------------------------------------------
+                    // Convert the parsed date into milliseconds and generate a duration,
+                    // then ask to save to the calendar.
+                    // -------------------------------------------------------------------
+                    Calendar now = Calendar.getInstance(); // for use in comparing
+                    Calendar cal = Calendar.getInstance();
+                    cal.setTime(startDate);
+
+                    Log.d(TAG, "-- current year: " + now.get(Calendar.YEAR));
+                    Log.d(TAG, "-- parsed date's year: " + cal.get(Calendar.YEAR));
+
+                    // Since the Year's not included in the date string we parsed, the date
+                    // we're given could be in the past. If so, we need to update the year.
+                    if(cal.getTimeInMillis() < now.getTimeInMillis()) {
+                        cal.set(Calendar.YEAR, now.get(Calendar.YEAR) + 1);
+                    }
+
+                    Log.d(TAG, "---> DATE: " + cal.toString());
+
+                    // Make all events a 2-hour duration.
+                    long start = cal.getTimeInMillis();
+                    cal.add(Calendar.HOUR_OF_DAY, 2);
+                    long end = cal.getTimeInMillis();
+
+                    // launch an intent for the calendar
+                    Intent intent = new Intent(Intent.ACTION_EDIT);
+                    intent.setType("vnd.android.cursor.item/event");
+                    intent.putExtra("title", "My Great new event");
+                    intent.putExtra("description", "And heres' an description to let me know what's happening.");
+                    intent.putExtra("beginTime", start);
+                    intent.putExtra("endTime", end);
+                    startActivity(intent);
+
+                } else {
+                    Log.d(TAG, "No Date string found");
+                }
+
                 break;
         }
     }

--- a/src/main/java/org/tndata/android/compass/adapter/ActionAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/ActionAdapter.java
@@ -5,6 +5,7 @@ import android.graphics.Color;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.text.Html;
+import android.util.Log;
 import android.view.View;
 
 import org.tndata.android.compass.R;
@@ -213,8 +214,6 @@ public class ActionAdapter
                 break;
 
             case R.id.action_add_to_calendar:
-                // NOTE: Let's save this as a positive action, prior to adding to their calendar.
-                mListener.onIDidItClick();
                 mListener.sendToCalendar();
                 break;
         }

--- a/src/main/java/org/tndata/android/compass/adapter/ActionAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/ActionAdapter.java
@@ -126,8 +126,14 @@ public class ActionAdapter
         else{
             holder.addButton(R.id.action_reschedule, R.string.action_reschedule, this);
         }
+
         if (mAction instanceof UserAction && !((UserAction)mAction).getExternalResource().isEmpty()){
-            holder.addButton(R.id.action_do_it_now, R.string.action_do_it_now, this);
+            if(((UserAction)mAction).getExternalResourceName().equals("datetime")){
+                holder.addButton(R.id.action_add_to_calendar, R.string.action_add_to_calendar, this);
+            }
+            else {
+                holder.addButton(R.id.action_do_it_now, R.string.action_do_it_now, this);
+            }
         }
         holder.addButton(R.id.action_did_it, R.string.action_did_it, this);
     }
@@ -198,6 +204,12 @@ public class ActionAdapter
             case R.id.material_header_subtitle:
                 mListener.onBehaviorInfoClick();
                 break;
+
+            case R.id.action_add_to_calendar:
+                // NOTE: Let's save this as a positive action, prior to adding to their calendar.
+                mListener.onIDidItClick();
+                mListener.sendToCalendar();
+                break;
         }
     }
 
@@ -243,5 +255,6 @@ public class ActionAdapter
         void onRescheduleClick();
         void onSnoozeClick();
         void onBehaviorInfoClick();
+        void sendToCalendar();
     }
 }

--- a/src/main/java/org/tndata/android/compass/adapter/ActionAdapter.java
+++ b/src/main/java/org/tndata/android/compass/adapter/ActionAdapter.java
@@ -11,6 +11,7 @@ import org.tndata.android.compass.R;
 import org.tndata.android.compass.model.Action;
 import org.tndata.android.compass.model.CustomAction;
 import org.tndata.android.compass.model.Reward;
+import org.tndata.android.compass.model.TDCAction;
 import org.tndata.android.compass.model.TDCCategory;
 import org.tndata.android.compass.model.UserAction;
 import org.tndata.android.compass.parser.Parser;
@@ -190,7 +191,13 @@ public class ActionAdapter
                 break;
 
             case R.id.action_do_it_now:
-                CompassUtil.doItNow(getContext(), ((UserAction)mAction).getExternalResource());
+                TDCAction action = ((UserAction)mAction).getAction();
+                if(action.hasLinkResource()) {
+                    CompassUtil.doItNow(getContext(), action.getExternalResource());
+                }
+                else if(action.hasPhoneNumberResource()){
+                    CompassUtil.callPhoneNumber(getContext(), action.getExternalResource());
+                }
                 break;
 
             case R.id.action_reschedule:

--- a/src/main/java/org/tndata/android/compass/model/TDCAction.java
+++ b/src/main/java/org/tndata/android/compass/model/TDCAction.java
@@ -25,6 +25,8 @@ public class TDCAction extends TDCContent{
     private String mExternalResource;
     @SerializedName("external_resource_name")
     private String mExternalResourceName;
+    @SerializedName("external_resource_type")
+    private String getmExternalResourceType;
 
     @SerializedName("behavior")
     private long mBehaviorId;
@@ -84,6 +86,15 @@ public class TDCAction extends TDCContent{
     }
 
     /**
+     * External resource type getter.
+     *
+     * @return the action's external resource type.
+     */
+    public String getExternalResourceType(){
+        return getmExternalResourceType;
+    }
+
+    /**
      * Behavior id getter.
      *
      * @return the id of the action's parent behavior.
@@ -135,6 +146,18 @@ public class TDCAction extends TDCContent{
         dest.writeString(mExternalResourceName);
         dest.writeLong(mBehaviorId);
         dest.writeString(mBehaviorTitle);
+    }
+
+    public boolean hasDatetimeResource() {
+        return getExternalResourceType() == "datetime";
+    }
+
+    public boolean hasPhoneNumberResource() {
+        return getExternalResourceType() == "phone";
+    }
+
+    public boolean hasLinkResource() {
+        return getExternalResourceType() == "link";
     }
 
     public static final Creator<TDCAction> CREATOR = new Creator<TDCAction>(){

--- a/src/main/java/org/tndata/android/compass/model/TDCAction.java
+++ b/src/main/java/org/tndata/android/compass/model/TDCAction.java
@@ -26,7 +26,7 @@ public class TDCAction extends TDCContent{
     @SerializedName("external_resource_name")
     private String mExternalResourceName;
     @SerializedName("external_resource_type")
-    private String getmExternalResourceType;
+    private String mExternalResourceType;
 
     @SerializedName("behavior")
     private long mBehaviorId;
@@ -91,7 +91,7 @@ public class TDCAction extends TDCContent{
      * @return the action's external resource type.
      */
     public String getExternalResourceType(){
-        return getmExternalResourceType;
+        return mExternalResourceType;
     }
 
     /**
@@ -144,20 +144,21 @@ public class TDCAction extends TDCContent{
         dest.writeString(mHtmlMoreInfo);
         dest.writeString(mExternalResource);
         dest.writeString(mExternalResourceName);
+        dest.writeString(mExternalResourceType);
         dest.writeLong(mBehaviorId);
         dest.writeString(mBehaviorTitle);
     }
 
     public boolean hasDatetimeResource() {
-        return getExternalResourceType() == "datetime";
+        return getExternalResourceType().equals("datetime");
     }
 
     public boolean hasPhoneNumberResource() {
-        return getExternalResourceType() == "phone";
+        return getExternalResourceType().equals("phone");
     }
 
     public boolean hasLinkResource() {
-        return getExternalResourceType() == "link";
+        return getExternalResourceType().equals("link");
     }
 
     public static final Creator<TDCAction> CREATOR = new Creator<TDCAction>(){
@@ -184,6 +185,7 @@ public class TDCAction extends TDCContent{
         mHtmlMoreInfo = src.readString();
         mExternalResource = src.readString();
         mExternalResourceName = src.readString();
+        mExternalResourceType = src.readString();
         mBehaviorId = src.readLong();
         mBehaviorTitle = src.readString();
     }

--- a/src/main/java/org/tndata/android/compass/model/UserAction.java
+++ b/src/main/java/org/tndata/android/compass/model/UserAction.java
@@ -70,6 +70,8 @@ public class UserAction extends Action implements ParserModels.ResultSet{
         return mAction.getExternalResourceName();
     }
 
+    public String getExternalResourceType() { return mAction.getExternalResourceType(); }
+
     public String getIconUrl(){
         return mAction.getIconUrl();
     }

--- a/src/main/java/org/tndata/android/compass/util/CompassUtil.java
+++ b/src/main/java/org/tndata/android/compass/util/CompassUtil.java
@@ -135,20 +135,6 @@ public final class CompassUtil{
         return "";
     }
 
-    /**
-     * Checks whether the provided string has one of the following formats, X being a number:
-     * <p/>
-     * (XXX) XXX-XXX
-     * XXX-XXX-XXXX
-     *
-     * @param resource the resource to be checked.
-     * @return true if the resource is a phone number, false otherwise.
-     */
-    public static boolean isPhoneNumber(String resource){
-        return resource.matches("[(][0-9]{3}[)] [0-9]{3}[-][0-9]{4}") ||
-                resource.matches("[0-9]{3}[-][0-9]{3}[-][0-9]{4}");
-    }
-
     public static void doItNow(@NonNull Context context, @NonNull String resource){
         //If a link
         if (resource.startsWith("http")){
@@ -170,18 +156,18 @@ public final class CompassUtil{
                 context.startActivity(new Intent(Intent.ACTION_VIEW, uri));
             }
         }
-        //If a phone number
-        else if (CompassUtil.isPhoneNumber(resource)){
-            //First of all, the number needs to be extracted from the resource
-            String number = "";
-            for (int i = 0; i < resource.length(); i++){
-                char digit = resource.charAt(i);
-                if (digit >= '0' && digit <= '9'){
-                    number += digit;
-                }
+    }
+
+    public static void callPhoneNumber(@NonNull Context context, @NonNull String resource) {
+        //First of all, the number needs to be extracted from the resource
+        String number = "";
+        for (int i = 0; i < resource.length(); i++){
+            char digit = resource.charAt(i);
+            if (digit >= '0' && digit <= '9'){
+                number += digit;
             }
-            context.startActivity(new Intent(Intent.ACTION_DIAL, Uri.parse("tel:" + number)));
         }
+        context.startActivity(new Intent(Intent.ACTION_DIAL, Uri.parse("tel:" + number)));
     }
 
     @DrawableRes

--- a/src/main/res/layout/activity_playground.xml
+++ b/src/main/res/layout/activity_playground.xml
@@ -6,6 +6,14 @@
     android:layout_height="match_parent"
     android:gravity="center" >
 
+
+    <Button
+        android:id="@+id/playground_button_calendar"
+        android:layout_width="wrap_content"
+        android:layout_height="50dp"
+        android:padding="10dp"
+        android:text="Share in your Calendar" />
+
     <Button
         android:id="@+id/playground_button_start"
         android:layout_width="wrap_content"

--- a/src/main/res/values/ids.xml
+++ b/src/main/res/values/ids.xml
@@ -17,6 +17,7 @@
     <item name="action_do_it_now" type="id" />
     <item name="action_snooze" type="id" />
     <item name="action_reschedule" type="id" />
+    <item name="action_add_to_calendar" type="id" />
 
     <item name="review_title" type="id" />
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -130,6 +130,7 @@
     <string name="survey_default_option">Click to choose</string>
 
     <!-- ActionActivity -->
+    <string name="action_add_to_calendar">Add to Calendar</string>
     <string name="action_do_it_now">Do it now</string>
     <string name="action_snooze">Later</string>
     <string name="action_reschedule">Reschedule</string>


### PR DESCRIPTION
If an Action/Notification has a scheduled date & time, we'll give them an option to add it to their calendar. This happens when an `Action`'s `externalResource` includes a datetime formatted string of the form `YYYY-mm-dd HH:MM:SS` and the `externalResourceName` is `datetime`.

Additionally, this PR adds `TDCAction.external_resource_type` with getters and some util methods to let us know what sort of resource (if any) is included in the action. It also updates the `doItNow` method and adds a `callPhoneNumber` method replacing the previous code that had to parse a phone number.