### PR TITLE
Display master illustration if category image urls are an empty string

### DIFF
--- a/src/main/java/org/tndata/android/compass/activity/ReviewActionsActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/ReviewActionsActivity.java
@@ -125,7 +125,7 @@ public class ReviewActionsActivity
     private void setCategoryHeader(TDCCategory category){
         View header = inflateHeader(R.layout.header_hero);
         ImageView hero = (ImageView)header.findViewById(R.id.header_hero_image);
-        if (category.getImageUrl() == null){
+        if (category.getImageUrl() == null || category.getImageUrl().isEmpty()){
             hero.setImageResource(R.drawable.compass_master_illustration);
         }
         else{


### PR DESCRIPTION
Yet another place where a category url may be an empty string instead of null. We want to display the master illustration instead of the compass icon placeholder.