### PR TITLE
Add ability to remove goals

### DIFF
--- a/src/main/java/org/tndata/android/compass/activity/ReviewActionsActivity.java
+++ b/src/main/java/org/tndata/android/compass/activity/ReviewActionsActivity.java
@@ -5,8 +5,11 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
+import android.widget.Toast;
 
 import org.tndata.android.compass.CompassApplication;
 import org.tndata.android.compass.R;
@@ -58,6 +61,7 @@ public class ReviewActionsActivity
     //Network request codes and urls
     private int mGetUserCategoryRC;
     private int mGetActionsRC;
+    private int mDeleteGoalRC;
     private String mGetActionsNextUrl;
 
 
@@ -191,6 +195,10 @@ public class ReviewActionsActivity
         else if (requestCode == mGetActionsRC){
             Parser.parse(result, ParserModels.UserActionResultSet.class, this);
         }
+        else if (requestCode == mDeleteGoalRC){
+            Toast.makeText(this, R.string.goal_removed_toast, Toast.LENGTH_SHORT).show();
+            finish();
+        }
     }
 
     @Override
@@ -218,5 +226,27 @@ public class ReviewActionsActivity
                 mAdapter.displayError("There are no activities");
             }
         }
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu){
+        if (mUserGoal == null){
+            return false;
+        }
+        getMenuInflater().inflate(R.menu.menu_goal_remove, menu);
+        return true;
+    }
+
+    @Override
+    public boolean menuItemSelected(MenuItem item){
+        switch (item.getItemId()){
+            case R.id.review_actions_remove_goal:
+                String url = API.getDeleteGoalUrl(mUserGoal);
+                mDeleteGoalRC = HttpRequest.delete(this, url);
+                break;
+            default:
+                return false;
+        }
+        return true;
     }
 }

--- a/src/main/res/menu/menu_goal_remove.xml
+++ b/src/main/res/menu/menu_goal_remove.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto" >
+
+    <item
+        android:id="@+id/review_actions_remove_goal"
+        android:title="@string/goal_remove"
+        android:titleCondensed="@string/goal_remove_condensed"
+        app:showAsAction="never" />
+
+</menu>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -129,6 +129,11 @@
     <string name="button_negative">CANCEL</string>
     <string name="survey_default_option">Click to choose</string>
 
+    <!-- ReviewActionsActivity -->
+    <string name="goal_remove">Remove Goal</string>
+    <string name="goal_remove_condensed">Remove</string>
+    <string name="goal_removed_toast">Your goal has been removed</string>
+
     <!-- ActionActivity -->
     <string name="action_do_it_now">Do it now</string>
     <string name="action_snooze">Later</string>


### PR DESCRIPTION
This PR adds an overflow menu to the `ReviewActionsActivity` that allows a user to remove the goal. Upon completion of the http DELETE request, there's a confirmation Toast and the activity is closed.