### PR TITLE
Don't ever let a category's Icon URL be null

### DIFF
--- a/src/main/java/org/tndata/android/compass/model/TDCContent.java
+++ b/src/main/java/org/tndata/android/compass/model/TDCContent.java
@@ -21,7 +21,7 @@ public abstract class TDCContent extends TDCBase implements Parcelable, Comparab
     @SerializedName("html_description")
     private String mHtmlDescription;
     @SerializedName("icon_url")
-    private String mIconUrl;
+    private String mIconUrl = "";
 
 
     public TDCContent(){
@@ -67,7 +67,10 @@ public abstract class TDCContent extends TDCBase implements Parcelable, Comparab
     }
 
     public String getIconUrl(){
-        return mIconUrl;
+        if(mIconUrl != null){
+            return mIconUrl;
+        }
+        return "";
     }
 
 


### PR DESCRIPTION
This fixes an issue where the app may hang on login _if_ the user trying to log in has selected a category whose icon is `null`. The app will throw an exception like this, but the UI appears to wait indefinitely.

```
W/System.err: java.lang.IllegalArgumentException: the bind value at index 5 is null
W/System.err:     at android.database.sqlite.SQLiteProgram.bindString(SQLiteProgram.java:164)
W/System.err:     at org.tndata.android.compass.database.TDCCategoryTableHandler.writeCategories(TDCCategoryTableHandler.java:96)
W/System.err:     at org.tndata.android.compass.CompassApplication.setAvailableCategories(CompassApplication.java:126)
W/System.err:     at org.tndata.android.compass.fragment.LogInFragment.onProcessResult(LogInFragment.java:219)
W/System.err:     at org.tndata.android.compass.parser.ParserWorker.parse(ParserWorker.java:55)
W/System.err:     at org.tndata.android.compass.parser.ParserWorker.doInBackground(ParserWorker.java:38)
W/System.err:     at org.tndata.android.compass.parser.ParserWorker.doInBackground(ParserWorker.java:15)
W/System.err:     at android.os.AsyncTask$2.call(AsyncTask.java:295)
W/System.err:     at java.util.concurrent.FutureTask.run(FutureTask.java:237)
W/System.err:     at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:234)
W/System.err:     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
W/System.err:     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
W/System.err:     at java.lang.Thread.run(Thread.java:818)
```

This fix initialized the category's `mIconUrl` to an empty string and performs a check for null values in the `getIconUrl` method.